### PR TITLE
chore: add CODEOWNERS for branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for zowe-mcp.
+#
+# An approving review from any of these owners satisfies the "Require review
+# from Code Owners" branch-protection rule on `main`. Branch protection also
+# restricts who may merge `develop` to the zowe-cli-administrators team (repo
+# admins retain bypass).
+#
+# All owners must have write access for their reviews to count.
+
+* @zowe/zowe-cli-administrators @plavjanik @dkelosky


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so `main` branch protection can require an approving review from a code owner.

Owners: `@zowe/zowe-cli-administrators` plus `@plavjanik` and `@dkelosky` (all have write access, so their reviews count).

This is the bootstrap step before enabling branch protection on `main` (require 1 code-owner approval, enforce for admins) and `develop` (merges restricted to the administrators team; admins keep bypass). Same file is already on `develop` (commit b462e97).

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction.
- **Review**: Verified both code owners have write access to the repo.