### PR TITLE
ci: harden build job + enforce format and duplication gates (Phase 1 + 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,20 @@ on:
         required: false
         type: string
 
+# Least privilege: only the sticky PR comment needs write; everything else reads.
 permissions:
+  contents: read
   pull-requests: write
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: "!contains(github.event.head_commit.message || '', '[ci skip]')"
 
     env:
@@ -38,6 +46,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: npm
 
       # Default path (push / PR / dispatch with fallback): install strictly from
       # the committed lockfile, which already pins the fallback zowex-sdk. Use
@@ -70,6 +79,12 @@ jobs:
 
       - name: Lint Markdown
         run: npm run lint:md
+
+      - name: Check formatting (Prettier + shfmt)
+        run: npm run check-format
+
+      - name: Check code duplication (jscpd)
+        run: npm run duplication
 
       - name: Build (common + server)
         run: |

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -144,31 +144,40 @@ locally before Phase 1+ consumes them.
 
 No new tools; make `ci.yml` robust.
 
-- [ ] `concurrency` (cancel-in-progress) keyed on workflow + ref.
-- [ ] `timeout-minutes` on the job (start at 30).
-- [ ] Least-privilege `permissions`.
-- [ ] npm caching via `setup-node`.
-- [ ] Pin actions (or rely on Dependabot from Phase 4).
+- [x] `concurrency` (cancel-in-progress) keyed on workflow + ref.
+- [x] `timeout-minutes` on the job (30).
+- [x] Least-privilege `permissions` (`contents: read` + `pull-requests: write`).
+- [x] npm caching via `setup-node` (`cache: npm`).
+- [ ] Pin actions to SHAs — deferred to **Phase 4 Dependabot**; majors were
+  already bumped to Node-24-ready versions in the carry-overs PR
+  (checkout v6, setup-node v6, upload-artifact v7, sticky-comment v3).
 
 ## Phase 2 — Enforce existing quality scripts
 
 Each as its own job/step so failures are legible.
 
-- [ ] **Format**: `npm run check-format` (Prettier + shfmt `--check`).
+- [x] **Format**: `npm run check-format` (Prettier + shfmt `--check`) — enforced
+  in the `build` job. Required fixing a pre-existing `src/index.ts` Prettier
+  violation first (carry-overs PR).
 - [x] **Markdown**: `npm run lint:md` — enforced in the `build` job (PR-1b).
-- [ ] **Duplication**: `npm run duplication` (jscpd, 5% threshold).
+- [x] **Duplication**: `npm run duplication` (jscpd, 5% threshold) — enforced in
+  the `build` job. Currently 14 clones, well under threshold.
 - [x] **Typecheck**: `npm run typecheck --workspaces` — enforced in the `build`
   job. Type-checks `src/**` + `__tests__/**` per package (dev `tsconfig.json`,
   `--noEmit`). Required clearing a 59-error test type backlog in
   `@zowe/mcp-server` first (stale duplicate types, partial mocks, missing
   narrowing); the shared `__tests__/helpers/stub-backend.ts` keeps backend
   doubles complete going forward.
-- [ ] **Lint**: keep `npm run lint` (`--max-warnings 0`); optionally emit ESLint
-  SARIF and upload to code-scanning for inline PR annotations.
-- [ ] **Docs drift**: run `npm run generate-docs` then
-  `git diff --exit-code docs/mcp-reference.md` so a stale reference fails CI.
+- [x] **Lint**: `npm run lint` (`--max-warnings 0`) — already a `build`-job step
+  (predates this plan). ESLint SARIF → code-scanning is a future nice-to-have.
+- [ ] **Docs drift** — **blocked**: `npm run generate-docs` is non-deterministic
+  (the output embeds the current commit hash and a live timestamp in a TSO
+  example), so `git diff --exit-code docs/mcp-reference.md` would fail on every
+  commit. Make the generator deterministic (freeze the example timestamp; drop
+  or stabilize the commit/version header) before gating.
 - [ ] **Plugin schema validation**: validate bundled CLI-bridge plugin YAMLs
-  against `schemas/plugin-tools.schema.json`.
+  against `schemas/plugin-tools.schema.json`. Needs a validator (`ajv` is not
+  currently a dependency) — a small node script or `ajv-cli` dev dep.
 
 ## Phase 3 — Expand test execution
 


### PR DESCRIPTION
## Description

Completes **Phase 1** (job hardening) and the remaining clean **Phase 2** gates from the [CI hardening plan](https://github.com/zowe/zowe-mcp/blob/develop/docs/ci-hardening-plan.md). All low-risk; the format/duplication gates pass on current `develop`.

## Changes

**Phase 1 — harden the `build` job**
- `concurrency` (cancel-in-progress) keyed on workflow + ref — cancels superseded runs on rapid pushes.
- `timeout-minutes: 30` on the job (was unbounded).
- **Least-privilege `permissions`**: top-level `contents: read` + `pull-requests: write` (only the sticky comment needs write).
- npm caching via `setup-node` (`cache: npm`).

**Phase 2 — enforce existing quality scripts**
- `npm run check-format` (Prettier + shfmt) — placed before the build to fail fast.
- `npm run duplication` (jscpd, 5% threshold; 14 clones today, well under).

(Markdown, Typecheck, and Lint were already enforced in earlier PRs.)

## Deferred (documented in the plan, not in this PR)

- **Docs-drift gate** — **blocked**: `npm run generate-docs` is non-deterministic (output embeds the current commit hash and a live timestamp in a TSO example), so `git diff --exit-code` would fail on every commit. The generator needs to be made deterministic first.
- **Plugin-schema validation** — needs a validator (`ajv` is not a dependency).
- **Action SHA-pinning** — deferred to Phase 4 Dependabot (majors already bumped to Node-24-ready versions in the carry-overs PR).

## Testing

- `npm run check-format`, `npm run duplication`, `npm run lint:md` → all clean locally
- Workflow YAML validated
- CI green (this run exercises the new gates + hardening)

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Linting passes (`npm run lint`, `npm run lint:md`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — CI configuration only; no MCP tools, prompts, or server behavior change.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction — added the hardening and gates, verified each passes locally, and surfaced the docs-drift non-determinism blocker.
- **Review**: All gates green locally; CI watched.