### PR TITLE
ci: make generate-docs deterministic and gate docs drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,12 @@ jobs:
       - name: Generate MCP reference docs
         run: npm run generate-docs
 
+      # Docs-drift gate: the generator is deterministic (pinned mock clock, no
+      # commit hash in the header), so regenerating must not change the committed
+      # reference docs. If this fails, run `npm run generate-docs` and commit.
+      - name: Check MCP reference docs are up to date
+        run: git diff --exit-code docs/mcp-reference.md vendor/zowe/docs/mcp-reference-vendor.md
+
       - name: Build VS Code extension (VSIX)
         run: npm run package -w packages/zowe-mcp-vscode
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -2,7 +2,7 @@
 
 # Zowe MCP Server Reference
 
-> Auto-generated from the MCP server (v0.9.0, commit ec19149). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
+> Auto-generated from the MCP server (v0.10.0-dev). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
 
 This document describes all [Context](#context), [Data Sets](#data-sets), [USS](#uss), [TSO](#tso), [Jobs](#jobs), [Local Files](#local-files), [Other](#other), [db2 CLI Plugin Tools](#db2-cli-plugin-tools), [Tool Reference](#tool-reference), [Capability Tiers](#capability-tiers), [Prompts](#prompts), [Resource Templates](#resource-templates) provided by the Zowe MCP Server.
 
@@ -194,7 +194,7 @@ Return the Zowe MCP server info (version, backend, components) and the current s
 {
   "server": {
     "name": "Zowe MCP Server",
-    "version": "0.9.0",
+    "version": "0.10.0-dev",
     "description": "MCP server providing tools for z/OS systems including data sets, jobs, and UNIX System Services",
     "components": [
       "context",
@@ -461,11 +461,11 @@ Notes:
 | &ensp;├─ `storclass`         | `string`   | No       | SMS storage class.                                                                                                                                                                                                                                                                   |
 | &ensp;├─ `spaceUnits`        | `string`   | No       | Space unit type (TRACKS, CYLINDERS, etc.).                                                                                                                                                                                                                                           |
 | &ensp;├─ `usedPercent`       | `number`   | No       | Used space percentage.                                                                                                                                                                                                                                                               |
-| &ensp;├─ `usedExtents`       | `number`   | No       | Used extents count.                                                                                                                                                                                                                                                                  |
 | &ensp;├─ `primary`           | `number`   | No       | Primary allocation units.                                                                                                                                                                                                                                                            |
 | &ensp;├─ `secondary`         | `number`   | No       | Secondary allocation units.                                                                                                                                                                                                                                                          |
 | &ensp;├─ `devtype`           | `string`   | No       | Device type.                                                                                                                                                                                                                                                                         |
-| &ensp;└─ `volsers`           | `string`[] | No       | Multi-volume serial list.                                                                                                                                                                                                                                                            |
+| &ensp;├─ `volsers`           | `string`[] | No       | Multi-volume serial list.                                                                                                                                                                                                                                                            |
+| &ensp;└─ `usedExtents`       | `number`   | No       | Used extents count.                                                                                                                                                                                                                                                                  |
 
 #### Example Outputs
 
@@ -2213,13 +2213,13 @@ Output:
     "totalLines": 1,
     "startLine": 1,
     "returnedLines": 1,
-    "contentLength": 72,
+    "contentLength": 77,
     "mimeType": "text/plain",
     "hasMore": false
   },
   "data": {
     "lines": [
-      "TIME-10:16:02 AM. CPU-00:00:00 SERVICE-26895 SESSION-00:01:53 MAY 7,2026"
+      "TIME-05:30:00 PM. CPU-00:00:00 SERVICE-26895 SESSION-00:01:53 JANUARY 15,2026"
     ],
     "mimeType": "text/plain"
   }

--- a/packages/zowe-mcp-server/src/scripts/generate-docs.ts
+++ b/packages/zowe-mcp-server/src/scripts/generate-docs.ts
@@ -840,6 +840,11 @@ async function main(): Promise<void> {
   const { output, inputs: inputsPath } = parseArgs();
   log.info('Generating MCP reference documentation', { output, inputsPath });
 
+  // Pin the mock clock so time-dependent example output (e.g. the TSO `TIME`
+  // command) is deterministic across machines and runs — keeps the generated
+  // docs stable for the docs-drift CI check. Respect a caller-provided value.
+  process.env.ZOWE_MCP_MOCK_CLOCK_ISO ??= '2026-01-15T17:30:00Z';
+
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   // Create a temporary mock data directory via the init-mock CLI
@@ -1212,19 +1217,10 @@ async function main(): Promise<void> {
       }
       log.info('Collected prompt messages', { count: promptMessages.size });
 
-      // 5. Assemble the Markdown document
-      let commitHash = '';
-      try {
-        const gitResult = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
-          encoding: 'utf-8',
-        });
-        if (gitResult.status === 0 && gitResult.stdout) {
-          commitHash = gitResult.stdout.trim();
-        }
-      } catch {
-        // Not in a git repo or git not available
-      }
-
+      // 5. Assemble the Markdown document.
+      // NB: the header intentionally carries only the (stable) package version,
+      // not the git commit hash, so regenerating on a clean tree is
+      // deterministic and the docs-drift CI gate doesn't fail on every commit.
       const sections: string[] = [];
       // markdownlint front-matter: disable rules triggered by MCP tool/prompt
       // descriptions that the generator cannot control, and structural duplicates.
@@ -1232,7 +1228,7 @@ async function main(): Promise<void> {
         '<!-- markdownlint-disable MD004 MD009 MD012 MD024 MD031 MD032 MD034 MD036 MD037 MD060 -->\n'
       );
       sections.push(`# Zowe MCP Server Reference\n`);
-      const commitInfo = commitHash ? `, commit ${commitHash}` : '';
+      const commitInfo = '';
       sections.push(
         `> Auto-generated from the MCP server (v${SERVER_VERSION}${commitInfo}). ` +
           `Do not edit manually — run \`npx @zowe/mcp-server generate-docs\` to regenerate.\n`

--- a/packages/zowe-mcp-server/src/zos/mock/filesystem-mock-backend.ts
+++ b/packages/zowe-mcp-server/src/zos/mock/filesystem-mock-backend.ts
@@ -992,16 +992,24 @@ export class FilesystemMockBackend implements ZosBackend {
       return Promise.resolve(`WHO mock output\nUSER=${_userId ?? 'mockuser'}`);
     }
     if (verb === 'TIME') {
-      const now = new Date();
-      const hours = now.getHours();
+      // Honor an injected fixed clock so `generate-docs` produces deterministic
+      // example output; fall back to the real local time at runtime. When a
+      // fixed clock is set, format in UTC so the result is independent of the
+      // runner's timezone (CI is UTC, dev machines are not).
+      const fixedIso = process.env.ZOWE_MCP_MOCK_CLOCK_ISO;
+      const now = fixedIso ? new Date(fixedIso) : new Date();
+      const utc = Boolean(fixedIso);
+      const hours = utc ? now.getUTCHours() : now.getHours();
       const h12 = hours % 12 || 12;
       const ampm = hours < 12 ? 'AM' : 'PM';
       const hh = String(h12).padStart(2, '0');
-      const mm = String(now.getMinutes()).padStart(2, '0');
-      const ss = String(now.getSeconds()).padStart(2, '0');
-      const month = now.toLocaleString('en-US', { month: 'long' }).toUpperCase();
-      const day = now.getDate();
-      const year = now.getFullYear();
+      const mm = String(utc ? now.getUTCMinutes() : now.getMinutes()).padStart(2, '0');
+      const ss = String(utc ? now.getUTCSeconds() : now.getSeconds()).padStart(2, '0');
+      const month = now
+        .toLocaleString('en-US', { month: 'long', timeZone: utc ? 'UTC' : undefined })
+        .toUpperCase();
+      const day = utc ? now.getUTCDate() : now.getDate();
+      const year = utc ? now.getUTCFullYear() : now.getFullYear();
       const timeStr = `TIME-${hh}:${mm}:${ss} ${ampm}. CPU-00:00:00 SERVICE-26895 SESSION-00:01:53 ${month} ${day},${year}`;
       return Promise.resolve(timeStr);
     }

--- a/vendor/zowe/docs/mcp-reference-vendor.md
+++ b/vendor/zowe/docs/mcp-reference-vendor.md
@@ -2,7 +2,7 @@
 
 # Zowe CLI Plugin Tools Reference
 
-> Auto-generated from the Zowe MCP server (v0.9.0, commit ec19149). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
+> Auto-generated from the Zowe MCP server (v0.10.0-dev). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
 
 > For core Zowe MCP tools, see [docs/mcp-reference.md](../../../docs/mcp-reference.md).
 


### PR DESCRIPTION
## Description

Unblocks the **docs-drift gate** (Phase 2) deferred in [PR #13](https://github.com/zowe/zowe-mcp/pull/13). `npm run generate-docs` was non-deterministic, so a naive `generate-docs && git diff --exit-code` would fail on every commit. This makes the generator deterministic and adds the gate.

## Root cause → fix

Two sources of non-determinism (found via a two-consecutive-run diff):

1. **Git commit hash in the header** (changes every commit) → **dropped**; the header keeps the stable package version (`v0.10.0-dev`).
2. **TSO `TIME` example used the live local clock** (the only value that differed between two consecutive runs; its `contentLength` also drifted, and local-tz getters made it machine-dependent) → the mock now honors an injected **`ZOWE_MCP_MOCK_CLOCK_ISO`** and **formats in UTC** when set. `generate-docs` pins it (`2026-01-15T17:30:00Z`), so the time string and `contentLength` are stable across machines and runs. Runtime behavior is unchanged (no env var → real local time).

## Changes

- `generate-docs.ts`: drop the commit hash from the header; pin the mock clock in `main()`.
- `filesystem-mock-backend.ts`: TSO `TIME` honors `ZOWE_MCP_MOCK_CLOCK_ISO` and formats UTC when set.
- Regenerated both reference docs (`docs/mcp-reference.md`, `vendor/zowe/docs/mcp-reference-vendor.md`) — also captures a pending real field-order fix (`usedExtents`/`volsers`).
- CI: new **Check MCP reference docs are up to date** step (after the existing `generate-docs`) that fails on drift.

## Testing

- **Two consecutive generations are byte-identical** (was the failing condition)
- Simulated the gate locally: regenerate → `git diff --exit-code` clean ✓
- TSO suites pass (`tso-tools.integration`, `tso-command-validation` — 15 tests)
- `lint`, `lint:md`, `typecheck`, Prettier → clean

## Notes

- Placed the new CI step next to the existing `generate-docs` step (away from PR #13's edits) to avoid a merge conflict; the plan-doc checkbox for docs-drift will be flipped once both this and #13 land.
- The committed docs were generated with UTC formatting, so the Linux/UTC CI run is the cross-machine determinism check.

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Code compiles without errors (`npm run build`)
- [x] Linting passes (`npm run lint`, `npm run lint:md`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — docs generator + mock clock injection; no MCP tool/prompt/behavior change at runtime.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction — root-caused the non-determinism, made the generator deterministic, and added the gate.
- **Review**: Verified byte-identical regeneration and a passing simulated gate locally; CI watched.