### PR TITLE
ci: add npm audit gate + Dependabot (Phase 4, PR 1/2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # npm dependencies across the workspace root. Grouped to keep PR volume low:
+  # one PR for dev-dependency bumps, one for production. Security updates are
+  # always raised individually by Dependabot regardless of grouping.
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+
+  # Keep GitHub Actions current (replaces manual SHA-pinning of actions).
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,34 @@
+name: Audit
+
+# Dependency vulnerability scan. Runs on every PR and once daily so newly
+# disclosed advisories surface even without a code change. Production deps
+# only, failing at moderate+ (mirrors zowe/zowex).
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: npm audit (production, moderate+)
+        run: npm audit --omit=dev --audit-level=moderate

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -215,26 +215,14 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
 
 ## Phase 4 — Security & supply-chain
 
-- [ ] **`audit.yml`** (Decision 2 — mirror zowex):
-
-  ```yaml
-  name: Audit
-  on:
-    pull_request:
-      branches: [main, develop]
-    schedule:
-      - cron: "0 10 * * *"
-  permissions: { contents: read }
-  jobs:
-    audit:
-      runs-on: ubuntu-latest
-      timeout-minutes: 10
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-node@v4
-          with: { node-version: lts/* }
-        - run: npm audit --production --audit-level=moderate
-  ```
+- [x] **`audit.yml`** (Decision 2 — mirror zowex) — `npm audit --omit=dev
+  --audit-level=moderate` on push/PR (both branches) + a daily cron. To ship it
+  green, first cleared the production findings (high `fast-uri` path traversal
+  and moderate `hono` / `express-rate-limit` / `ip-address` / `qs`) with a
+  **targeted `npm update`** of just those 5 transitive packages (lockfile-only, no
+  `package.json` change; `npm audit fix` was rejected — it churned 98 packages).
+  Remaining 5 lows are evals-only `@ai-sdk/*` needing major bumps — below the
+  `moderate` gate; left to Dependabot.
 
 - [ ] **`codeql.yml`** — TypeScript only (no C/C++ in this repo):
 
@@ -258,19 +246,9 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
         - uses: github/codeql-action/analyze@v3
   ```
 
-- [ ] **`dependabot.yml`** — npm + github-actions ecosystems:
-
-  ```yaml
-  version: 2
-  updates:
-    - package-ecosystem: npm
-      directory: "/"
-      schedule: { interval: weekly }
-      groups: { dev-deps: { dependency-type: development } }
-    - package-ecosystem: github-actions
-      directory: "/"
-      schedule: { interval: weekly }
-  ```
+- [x] **`dependabot.yml`** — weekly `npm` (grouped dev vs production to limit PR
+  volume; security updates still raised individually) + `github-actions`
+  ecosystems. The actions ecosystem replaces manual SHA-pinning (Phase 1).
 
 - [ ] **Secret scanning** (gitleaks) — improvement beyond zowex; we handle
   tokens/credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1411,6 +1411,58 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1881,6 +1933,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/@secretlint/config-loader/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3552,6 +3621,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3853,6 +3938,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/boolbase": {
@@ -5577,22 +5677,19 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
-      "license": "MIT",
+    "node_modules/express/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "side-channel": "^1.1.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=0.6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5642,22 +5739,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -6225,15 +6306,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -6468,15 +6540,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -9658,21 +9721,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10882,6 +10930,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/table/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -11308,6 +11373,22 @@
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {
@@ -12115,6 +12196,22 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "packages/zowe-mcp-evals/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "packages/zowe-mcp-evals/node_modules/json-schema-traverse": {
       "version": "1.0.0",


### PR DESCRIPTION
## Description

First of two **Phase 4 (security & supply-chain)** PRs ([plan](https://github.com/zowe/zowe-mcp/blob/develop/docs/ci-hardening-plan.md)). Adds the dependency-audit gate and Dependabot, and clears the existing production vulnerabilities so the gate ships **green**. (PR 2/2 = CodeQL.)

## Changes

- **`audit.yml`** — `npm audit --omit=dev --audit-level=moderate` on push/PR (main + develop) and a daily cron. Production deps, fail at moderate+ (mirrors zowe/zowex, Decision 2).
- **Cleared the production findings** so the gate is green from day one: a **targeted `npm update`** of just the 5 vulnerable transitive packages —
  - `fast-uri` 3.1.0 → **3.1.2** (HIGH — path traversal)
  - `hono` 4.12.14 → **4.12.25** (moderate — CSS injection)
  - `express-rate-limit` 8.3.1 → **8.5.2** (moderate, via ip-address)
  - `ip-address` 10.1.0 → **10.2.0** (moderate — XSS)
  - `qs` 6.15.0 → **6.15.2** (moderate — DoS)

  Lockfile-only (no `package.json` change). I rejected `npm audit fix` — it churned **98 packages** (vite/esbuild/rolldown/vitest/…); the targeted update touches exactly these 5. The remaining 5 lows are evals-only `@ai-sdk/*` requiring semver-major bumps — below the `moderate` gate, left to Dependabot.
- **`dependabot.yml`** — weekly `npm` (grouped dev vs production to limit PR volume) + `github-actions`. The actions ecosystem supersedes the manual action SHA-pinning deferred in Phase 1.

## Testing

- `npm audit --omit=dev --audit-level=moderate` → **exit 0** (was 1)
- `npm ci --ignore-scripts` clean; **zowex-sdk lockfile integrity untouched** (verified)
- `npm run build`, `npm run typecheck` (0 errors), HTTP-transport tests (`http.e2e`, `http-transport-jwt` — 9 passed)
- `lint:md`, Prettier, both new YAMLs valid

## Notes

- The `audit` check is **not** (yet) a required status check — adding it to branch protection is a Phase 6 item. It runs and gates its own job today.
- Dependabot will start opening grouped weekly PRs once this lands on a branch it scans.

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Linting passes (`npm run lint`, `npm run lint:md`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — CI/security config + a transitive-dep security bump; no MCP tool/prompt/behavior change.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction — checked the live audit, chose the surgical fix over `npm audit fix`, verified the lockfile/SDK survived, authored the workflows.
- **Review**: Full local validation battery green; CI watched.