### PR TITLE
ci: add CodeQL SAST (Phase 4, PR 2/2)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: Zowe MCP CodeQL config
+
+# Analyze our own source only. Exclude vendored upstream code, build output,
+# generated artifacts, and dependencies (CodeQL ignores node_modules by default,
+# but list it for clarity).
+paths-ignore:
+  - vendor
+  - '**/dist'
+  - '**/out'
+  - '**/.vscode-test'
+  - coverage
+  - '**/node_modules'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+# Static analysis (SAST) for the TypeScript/JavaScript sources. Results appear
+# under Security → Code scanning. No C/C++ in this repo, so a single language.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 10 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -224,27 +224,11 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
   Remaining 5 lows are evals-only `@ai-sdk/*` needing major bumps — below the
   `moderate` gate; left to Dependabot.
 
-- [ ] **`codeql.yml`** — TypeScript only (no C/C++ in this repo):
-
-  ```yaml
-  name: CodeQL
-  on:
-    push: { branches: [main, develop] }
-    pull_request: { branches: [main, develop] }
-    schedule:
-      - cron: "0 10 * * 1"
-  jobs:
-    analyze:
-      runs-on: ubuntu-latest
-      timeout-minutes: 30
-      permissions: { actions: read, contents: read, security-events: write }
-      steps:
-        - uses: actions/checkout@v4
-        - uses: github/codeql-action/init@v3
-          with: { languages: javascript-typescript, queries: security-extended }
-        - uses: github/codeql-action/autobuild@v3
-        - uses: github/codeql-action/analyze@v3
-  ```
+- [x] **`codeql.yml`** — CodeQL SAST for `javascript-typescript` (no C/C++ here),
+  `build-mode: none` (source analysis, no build), `security-extended` queries,
+  on push/PR (main + develop) + a weekly cron. A `.github/codeql/codeql-config.yml`
+  scopes analysis to our own source (ignores `vendor`, `dist`, `out`, `coverage`).
+  Results surface under **Security → Code scanning**.
 
 - [x] **`dependabot.yml`** — weekly `npm` (grouped dev vs production to limit PR
   volume; security updates still raised individually) + `github-actions`


### PR DESCRIPTION
## Description

Second of two **Phase 4 (security)** PRs ([plan](https://github.com/zowe/zowe-mcp/blob/develop/docs/ci-hardening-plan.md)) — adds CodeQL static analysis. (PR 1/2 = `audit.yml` + Dependabot, merged.)

## Changes

- **`codeql.yml`** — CodeQL SAST for `javascript-typescript` (no C/C++ in this repo), `build-mode: none` (analyzes sources directly, no build step), the `security-extended` query suite, on push/PR (main + develop) + a weekly cron.
- **`.github/codeql/codeql-config.yml`** — scopes analysis to our own source: ignores `vendor` (vendored upstream), `dist`/`out`/`coverage` (build/generated), and `node_modules`. Keeps findings focused on code we own.

Results appear under **Security → Code scanning**.

## What to expect

`security-extended` on this codebase's auth/JWT/SSH/subprocess surface **may surface findings to triage** — I'll report whatever the first run flags rather than assume it's clean. CodeQL findings are informational alerts (Security tab); the `CodeQL` workflow check passes as long as analysis completes. It is **not** a required status check (adding required checks is a Phase 6 item), so it won't block merges regardless.

## Testing

- Both YAML files validated
- `lint:md`, Prettier clean
- The analysis itself runs in CI on this PR — I'll watch it and summarize any alerts

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Linting passes (`npm run lint:md`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — CI security config only; no MCP tool/prompt/behavior change.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction.
- **Review**: YAML validated; CI/analysis watched and triaged.