### PR TITLE
ci: add secret scanning (gitleaks) + license-header check (Phase 4 extras)

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,40 @@
+name: License headers
+
+# Verifies the EPL-2.0 SPDX header on non-TypeScript source files
+# (.js/.mjs/.cjs/.sh). TypeScript (.ts/.mts) is already enforced by
+# eslint-plugin-headers in the lint step of the build job; this covers the gap.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-headers-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  headers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check SPDX headers (non-TS source)
+        run: |
+          missing=0
+          while read -r f; do
+            if ! grep -q "SPDX-License-Identifier: EPL-2.0" "$f"; then
+              echo "::error file=$f::Missing EPL-2.0 SPDX license header"
+              missing=1
+            fi
+          done < <(git ls-files '*.js' '*.mjs' '*.cjs' '*.sh' | grep -vE '^vendor/')
+          if [ "$missing" -ne 0 ]; then
+            echo "One or more source files are missing the EPL-2.0 SPDX header."
+            exit 1
+          fi
+          echo "All non-TS source files carry the EPL-2.0 SPDX header."

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,39 @@
+name: Secret scan
+
+# Scans the working tree for committed secrets with gitleaks. Uses the OSS CLI
+# directly (the gitleaks GitHub Action requires a paid license for orgs).
+# Allowlist of known-public dev/test values lives in .gitleaks.toml.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 10 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: 8.30.1
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          ./gitleaks version
+
+      - name: Scan for secrets
+        run: ./gitleaks dir . --no-banner --redact --config .gitleaks.toml --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+title = "Zowe MCP gitleaks config"
+
+# Default rule set, plus an allowlist for values that are intentionally public
+# (dev/example/test) and for paths that aren't our source. Real secrets — in any
+# file, including tests — are still flagged. When a new fake secret in a test
+# trips a rule, add its exact value below rather than allowlisting whole trees.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-public dev/test values and non-source paths"
+regexTarget = "match"
+regexes = [
+  # infrastructure/local-registry + docs/mcp-registry-research.md — public dev
+  # credentials copied from the upstream MCP registry .env.example (no privileges).
+  '''0e8db54879b02c29adef51795586f3c510a9341d''',
+  '''bb2c6b424005acd5df47a9e2c87f446def86dd740c888ea3efb825b23f7ef47c''',
+  # test fixtures (not real secrets)
+  '''abc123def4567890''',
+  '''roundtrip-secret-99''',
+]
+paths = [
+  '''(^|/)vendor/''',          # vendored upstream content (not ours)
+  '''(^|/)node_modules/''',
+  '''(^|/)dist/''',
+  '''(^|/)out/''',
+  '''(^|/)\.vscode-test/''',   # downloaded VS Code (local/CI-generated)
+  '''(^|/)\.claude/''',        # local agent worktrees/scratch
+  '''remote-https-dev/certs/''', # local mkcert TLS material (gitignored)
+]

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -234,10 +234,15 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
   volume; security updates still raised individually) + `github-actions`
   ecosystems. The actions ecosystem replaces manual SHA-pinning (Phase 1).
 
-- [ ] **Secret scanning** (gitleaks) — improvement beyond zowex; we handle
-  tokens/credentials.
-- [ ] **License header check** — verify SPDX/EPL-2.0 headers on source files
-  (zowex runs a license step).
+- [x] **Secret scanning** (`secret-scan.yml`) — gitleaks via the OSS CLI (the
+  GitHub Action needs a paid org license), on push/PR + weekly cron. A
+  `.gitleaks.toml` allowlists known-public dev/test values by exact match (so
+  real secrets are still caught anywhere, including tests) and excludes
+  non-source paths.
+- [x] **License header check** (`license-headers.yml`) — verifies the EPL-2.0
+  SPDX header on non-TS source (`.js`/`.mjs`/`.cjs`/`.sh`); `.ts`/`.mts` are
+  already enforced by `eslint-plugin-headers` in the lint step. Added the header
+  to 6 files that were missing it.
 - [ ] *(Optional / later)* `step-security/harden-runner`, OpenSSF Scorecard,
   SBOM (CycloneDX).
 

--- a/packages/zowe-mcp-server/scripts/copy-resources.cjs
+++ b/packages/zowe-mcp-server/scripts/copy-resources.cjs
@@ -1,3 +1,13 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 /**
  * Copies src/resources into dist/resources and non-TypeScript assets from
  * src/tools/* into their dist counterparts so packaged resources are available

--- a/packages/zowe-mcp-server/scripts/test-airgap-install.sh
+++ b/packages/zowe-mcp-server/scripts/test-airgap-install.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 #
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
+#
 # Test that the packed tarball can be installed in an airgapped/offline environment.
 # Uses an empty cache and invalid registry to simulate no network access.
 #

--- a/scripts/keycloak-dev-fresh.sh
+++ b/scripts/keycloak-dev-fresh.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
 # Recreate Keycloak (native HTTPS merge) with an empty dev database, then run keycloak-init.
 # Same compose files as npm run start:remote-https-dev-native-zos — not the HTTP-only Keycloak stack.
 #

--- a/scripts/local-registry-wipe-publish-dev.sh
+++ b/scripts/local-registry-wipe-publish-dev.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
 # Wipe the local MCP registry (Docker Postgres volume) and republish
 # packages/zowe-mcp-server/remote-server-example-dev.json for gallery testing.
 #

--- a/scripts/rephrase-tool-descriptions.mjs
+++ b/scripts/rephrase-tool-descriptions.mjs
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 /**
  * Rephrase Tool Descriptions — AI-assisted tool for generating optimized
  * Endevor tool descriptions from CLI text.

--- a/scripts/start-remote-https-dev-native-zos.sh
+++ b/scripts/start-remote-https-dev-native-zos.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#
 # Keycloak native HTTPS (TLS inside Keycloak JVM) + nginx TLS for MCP only.
 # Public URLs (defaults):
 #   MCP:  https://zowe.mcp.example.com:7542  (nginx TLS → Node HTTP on ZOWE_MCP_HTTP_BACKEND_PORT, default 7543)


### PR DESCRIPTION
## Description

The two optional **Phase 4** extras ([plan](https://github.com/zowe/zowe-mcp/blob/develop/docs/ci-hardening-plan.md)), as standalone workflows.

## Changes

**`secret-scan.yml`** — gitleaks via the OSS CLI (pinned 8.30.1). The official `gitleaks-action` requires a **paid license for organizations**, so this downloads and runs the CLI directly. On push/PR (main + develop) + weekly cron.
- **`.gitleaks.toml`** extends the default rules and allowlists by **exact value** the 4 known-public dev/test strings (the local-registry/`mcp-registry-research.md` "public dev credentials from upstream .env.example", a test cache key, a test pipe-handshake secret) — so real secrets are still flagged **anywhere, including tests**. Also excludes non-source paths (`vendor`, `node_modules`, `dist`, `out`, `.vscode-test`, `.claude`, local certs).
- Baseline: a default scan flagged 120 hits, but all but 6 were local-only noise (`.vscode-test`/`.claude`/gitignored certs absent in a CI checkout); the 6 tracked findings are all confirmed-fake and allowlisted. Tracked tree now scans **clean**.

**`license-headers.yml`** — verifies the EPL-2.0 SPDX header on **non-TS** source (`.js`/`.mjs`/`.cjs`/`.sh`); `.ts`/`.mts` are already gated by `eslint-plugin-headers` in the build job's lint step, so this closes the gap. Emits `::error file=` annotations on offenders.
- Added the header to the **6 files** that were missing it (`copy-resources.cjs`, `rephrase-tool-descriptions.mjs`, and 4 shell scripts).

## Testing

- gitleaks with the config → **0 findings** on the tracked tree
- License-header check logic replicated locally → **0 missing**
- `check-format` (Prettier + shfmt, covers the new headers in `.cjs`/`.mjs`/`.sh`) and `lint:md` → clean
- All three new YAMLs validated

## Notes

- Neither check is a *required* status check yet — that's a Phase 6 item (along with `audit`/`CodeQL`).
- `.gitleaks.toml` documents that new fake test secrets should be added to the allowlist by value rather than allowlisting whole trees.

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Linting passes (`npm run lint`, `npm run lint:md`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — CI security config + license headers; no MCP tool/prompt/behavior change.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction — baseline-scanned with gitleaks, confirmed each flagged value was fake before allowlisting, added missing headers, authored the workflows.
- **Review**: Local scans clean; CI watched.