### PR TITLE
fix(pack): make dependency bundling work on macOS (Phase 5 prerequisite)

### DIFF
--- a/packages/zowe-mcp-server/scripts/bundle-for-pack.cjs
+++ b/packages/zowe-mcp-server/scripts/bundle-for-pack.cjs
@@ -49,57 +49,73 @@ const fileDepDirs = [
   { prefix: 'file:../../resources/', absDir: path.join(repoRoot, 'resources') },
 ];
 
-// 1. Backup original package.json
-const originalPkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-fs.writeFileSync(backupPath, JSON.stringify(originalPkg, null, 2));
+// 1. Backup original package.json verbatim (byte-exact, so postpack can restore
+//    it without changing formatting — e.g. the trailing newline).
+fs.copyFileSync(packageJsonPath, backupPath);
 
-// 2. Rewrite deps in-place (workspace → .local/, file: tgz → .unpack/)
-bundleWorkspaceDep({
-  targetDir: serverPkgDir,
-  targetPackageJsonPath: packageJsonPath,
-  depName: 'zowe-mcp-common',
-  depSourceDir: commonPkgDir,
-});
+// Everything after the backup is wrapped so a failure restores the original
+// package.json and removes scratch dirs — otherwise a crash here leaves the repo
+// half-rewritten (postpack, which restores, only runs after a *successful* pack).
+try {
+  // 2. Rewrite deps in-place (workspace → .local/, file: tgz → .unpack/)
+  bundleWorkspaceDep({
+    targetDir: serverPkgDir,
+    targetPackageJsonPath: packageJsonPath,
+    depName: 'zowe-mcp-common',
+    depSourceDir: commonPkgDir,
+  });
 
-prepareFileDepsForBundle({
-  targetDir: serverPkgDir,
-  targetPackageJsonPath: packageJsonPath,
-  fileDepDirs,
-});
+  prepareFileDepsForBundle({
+    targetDir: serverPkgDir,
+    targetPackageJsonPath: packageJsonPath,
+    fileDepDirs,
+  });
 
-// 3. Create an isolated temp directory and copy the rewritten package.json
-//    plus the .local/ and .unpack/ directories into it. This is outside the
-//    monorepo so npm install doesn't hoist deps to the workspace root.
-const isoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zowe-mcp-pack-'));
-fs.cpSync(packageJsonPath, path.join(isoDir, 'package.json'));
-for (const dir of ['.local', '.unpack']) {
-  const src = path.join(serverPkgDir, dir);
-  if (fs.existsSync(src)) {
-    fs.cpSync(src, path.join(isoDir, dir), { recursive: true });
+  // 3. Create an isolated temp directory and copy the rewritten package.json
+  //    plus the .local/ and .unpack/ directories into it. This is outside the
+  //    monorepo so npm install doesn't hoist deps to the workspace root.
+  const isoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zowe-mcp-pack-'));
+  fs.cpSync(packageJsonPath, path.join(isoDir, 'package.json'));
+  for (const dir of ['.local', '.unpack']) {
+    const src = path.join(serverPkgDir, dir);
+    if (fs.existsSync(src)) {
+      fs.cpSync(src, path.join(isoDir, dir), { recursive: true });
+    }
   }
+
+  // 4. Run npm install in the isolated directory
+  console.log('Installing production dependencies in isolated directory...');
+  npmInstallProduction(isoDir);
+
+  // 5. Dereference symlinks created by file: deps
+  dereferenceSymlinks(path.join(isoDir, 'node_modules'));
+
+  // 6. Copy the node_modules tree into the server package directory
+  const targetNodeModules = path.join(serverPkgDir, 'node_modules');
+  if (fs.existsSync(targetNodeModules)) {
+    fs.rmSync(targetNodeModules, { recursive: true, force: true });
+  }
+  fs.cpSync(path.join(isoDir, 'node_modules'), targetNodeModules, { recursive: true });
+
+  // Clean up the temp directory
+  fs.rmSync(isoDir, { recursive: true, force: true });
+
+  // 7. Add bundledDependencies: true so npm pack includes the node_modules/ tree.
+  //    This flag is NOT in the committed package.json (it would cause npm install
+  //    to skip deps during development). We add it here only for the pack phase.
+  const modifiedPkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  modifiedPkg.bundledDependencies = true;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(modifiedPkg, null, 2));
+  console.log('Prepack complete — bundledDependencies will include node_modules/ in the tarball.');
+} catch (err) {
+  // Restore the original package.json and remove scratch dirs so a failed
+  // prepack doesn't leave the working tree broken (which then breaks npm ci).
+  if (fs.existsSync(backupPath)) {
+    fs.writeFileSync(packageJsonPath, fs.readFileSync(backupPath, 'utf-8'));
+    fs.unlinkSync(backupPath);
+  }
+  for (const dir of ['.local', '.unpack', '.extract-tmp']) {
+    fs.rmSync(path.join(serverPkgDir, dir), { recursive: true, force: true });
+  }
+  throw err;
 }
-
-// 4. Run npm install in the isolated directory
-console.log('Installing production dependencies in isolated directory...');
-npmInstallProduction(isoDir);
-
-// 5. Dereference symlinks created by file: deps
-dereferenceSymlinks(path.join(isoDir, 'node_modules'));
-
-// 6. Copy the node_modules tree into the server package directory
-const targetNodeModules = path.join(serverPkgDir, 'node_modules');
-if (fs.existsSync(targetNodeModules)) {
-  fs.rmSync(targetNodeModules, { recursive: true, force: true });
-}
-fs.cpSync(path.join(isoDir, 'node_modules'), targetNodeModules, { recursive: true });
-
-// Clean up the temp directory
-fs.rmSync(isoDir, { recursive: true, force: true });
-
-// 7. Add bundledDependencies: true so npm pack includes the node_modules/ tree.
-//    This flag is NOT in the committed package.json (it would cause npm install
-//    to skip deps during development). We add it here only for the pack phase.
-const modifiedPkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-modifiedPkg.bundledDependencies = true;
-fs.writeFileSync(packageJsonPath, JSON.stringify(modifiedPkg, null, 2));
-console.log('Prepack complete — bundledDependencies will include node_modules/ in the tarball.');

--- a/packages/zowe-mcp-server/scripts/restore-after-pack.cjs
+++ b/packages/zowe-mcp-server/scripts/restore-after-pack.cjs
@@ -24,10 +24,10 @@ const repoRoot = path.resolve(serverPkgDir, '..', '..');
 const packageJsonPath = path.join(serverPkgDir, 'package.json');
 const backupPath = path.join(serverPkgDir, '.package.json.backup');
 
-// Restore original package.json
+// Restore original package.json verbatim (byte-exact — preserves formatting,
+// e.g. the trailing newline, so packing leaves the working tree clean).
 if (fs.existsSync(backupPath)) {
-  const originalPkg = JSON.parse(fs.readFileSync(backupPath, 'utf-8'));
-  fs.writeFileSync(packageJsonPath, JSON.stringify(originalPkg, null, 2));
+  fs.copyFileSync(backupPath, packageJsonPath);
   fs.unlinkSync(backupPath);
   console.log('Restored original package.json');
 } else {

--- a/scripts/bundle-production-deps.cjs
+++ b/scripts/bundle-production-deps.cjs
@@ -180,7 +180,11 @@ function dereferenceSymlinks(dir) {
         // Broken symlink — skip
         continue;
       }
-      fs.rmSync(full, { force: true });
+      // Remove the symlink itself (not its target). `recursive: true` is
+      // required for symlinks pointing at a directory — without it, newer Node
+      // throws ERR_FS_EISDIR ("Path is a directory") on macOS. rmSync does not
+      // traverse the link, so the target tree is untouched and is copied below.
+      fs.rmSync(full, { recursive: true, force: true });
       const realStat = fs.statSync(realPath);
       if (realStat.isDirectory()) {
         fs.cpSync(realPath, full, { recursive: true });


### PR DESCRIPTION
## Description

Prerequisite for **Phase 5 (cross-platform matrix)**: the dependency-bundling scripts crash on macOS, which would block the macOS matrix leg (`pack:server` and the VSIX `bundle:server`). This fixes the crash and hardens the package.json round-trip.

## The bug

`npm run pack:server` / `bundle:server` failed on macOS (newer Node, incl. Node 24/25) with:

```text
Error: Path is a directory: <tmp>/node_modules/zowe-mcp-common   (ERR_FS_EISDIR)
    at dereferenceSymlinks (scripts/bundle-production-deps.cjs:183)
```

`dereferenceSymlinks` removed the `node_modules/zowe-mcp-common` file: symlink with `fs.rmSync(full, { force: true })`. For a symlink pointing at a **directory**, newer Node throws `ERR_FS_EISDIR` without `recursive: true`. Linux CI was unaffected (older behavior), which is why it only showed up locally on macOS.

## Fix

- **`bundle-production-deps.cjs`**: `fs.rmSync(full, { recursive: true, force: true })` when removing the symlink. `rmSync` removes the link, **not** the target — verified the bundled tarball still contains the full `zowe-mcp-common/dist`.
- **Crash hygiene** (`bundle-for-pack.cjs`): wrap the mutating steps in try/catch that restores `package.json` and removes `.local`/`.unpack` on failure. Previously a prepack crash left `package.json` rewritten (postpack only runs after a *successful* pack), which then broke `npm ci` — this cost real debugging time during Phase 3.
- **Byte-exact round-trip** (`bundle-for-pack.cjs` + `restore-after-pack.cjs`): back up / restore `package.json` with `copyFileSync` instead of `JSON.parse`→`stringify`, which had been stripping the trailing newline and dirtying the tree after every pack.

## Testing (all on macOS, where it previously failed)

- `npm run pack:server` → tarball produced, **working tree clean** after
- `npm run test:airgap` → "Offline airgap test passed", binary runs
- `npm run test:vscode` → "Server bundled successfully", 18 passing
- `check-format` clean; only the 3 scripts change

## Why now

Closes the macOS blocker identified in the Phase 5 assessment (and the issue first flagged during Phase 3). With this in, the Phase 5 PR can add the full **windows + macos** matrix.

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Linting/format passes (`npm run check-format`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

N/A — build/packaging tooling; no MCP tool/prompt/behavior change.

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: AI-generated under human direction — reproduced with a stack trace, fixed the symlink removal + crash hygiene, validated pack/airgap/vscode on macOS.
- **Review**: Full local validation on macOS; CI watched.