### PR TITLE
ci: ci-ok aggregate gate + advisory changelog check (Phase 6)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,51 @@
+name: Changelog
+
+# Reminds contributors to record user-facing changes. A PR passes when it edits
+# a CHANGELOG.md (root or any package), or carries the `no-changelog` label for
+# changes that don't warrant an entry (CI, chore, internal refactors, docs).
+#
+# Not a required check (see CONTRIBUTING.md) — it's an advisory gate that pairs
+# with later release-automation work. The `labeled`/`unlabeled` triggers let the
+# check re-run the moment the escape-hatch label is added or removed.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: changelog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require a CHANGELOG.md entry (or the 'no-changelog' label)
+        env:
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "PR has the 'no-changelog' label — a changelog entry is not required."
+            exit 0
+          fi
+          # Fetch the target branch so the merge-base diff (origin/<base>...HEAD)
+          # resolves to exactly this PR's changes.
+          git fetch --no-tags origin "$BASE"
+          changed=$(git diff --name-only "origin/$BASE...HEAD")
+          if printf '%s\n' "$changed" | grep -qE '(^|/)CHANGELOG\.md$'; then
+            echo "Changelog entry found:"
+            printf '%s\n' "$changed" | grep -E '(^|/)CHANGELOG\.md$'
+            exit 0
+          fi
+          echo "::error::This PR changes no CHANGELOG.md. Add an entry under [Unreleased] in CHANGELOG.md, or apply the 'no-changelog' label for changes that don't need one (CI, chore, docs, internal refactors)."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,27 @@ jobs:
       # Windows/macOS runners (xvfb is Linux-only).
       - name: Test (VS Code extension)
         run: npm run test:vscode
+
+  # Aggregate gate: one stable check name for branch protection to require, so
+  # adding, renaming, or sharding the CI jobs above never churns the protection
+  # config (only a brand-new *workflow* would). Runs even when an upstream job
+  # failed or was skipped (if: always()) and fails only if a needed job actually
+  # failed or was cancelled. A skipped job — e.g. a `[ci skip]` push, where build
+  # and cross-platform are guarded off — counts as a pass, so `[ci skip]` commits
+  # still satisfy the required check.
+  ci-ok:
+    name: ci-ok
+    needs: [build, cross-platform]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify required CI jobs succeeded
+        run: |
+          echo "build          = ${{ needs.build.result }}"
+          echo "cross-platform = ${{ needs.cross-platform.result }}"
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "::error::A required CI job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required CI jobs passed (or were skipped)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,21 @@ Server tests are organized into **common** (parameterized) and **transport-speci
 - **Cursor hook**: `.cursor/hooks/duplication.sh` runs automatically after Agent file edits (not Tab edits) on `.ts` files under `packages/`. It runs jscpd on the edited file and reports any duplication to the agent as advisory output. Always exits 0 (non-blocking).
 - **CI integration**: jscpd exits non-zero when duplication exceeds the configured `threshold`, suitable for CI quality gates.
 
+### Continuous Integration (GitHub Actions)
+
+Workflows live in `.github/workflows/`. The local Cursor hooks above are advisory; **CI is the enforcing copy of the same gates**, so a change that passes locally can still be blocked in CI. The full backlog and rationale are in `docs/ci-hardening-plan.md`; branch-protection details are in `CONTRIBUTING.md`.
+
+- **`ci.yml`** — the main pipeline, two jobs:
+  - **`build`** (ubuntu): installs with **`npm ci --ignore-scripts`** (lockfile-reproducible; the committed lockfile pins the fallback `zowex-sdk`, so `sdk-switch` is **not** run on the normal path), then runs every gate in order: `lint:md` → `check-format` (Prettier + shfmt) → `duplication` (jscpd) → build (common + server) → **`typecheck`** → `lint` (ESLint) → server **tests with coverage + JUnit** → `vscode-test` (under `xvfb-run`) → `pack` → **`test:airgap`** → `generate-docs` → **docs-drift check** → VSIX. Coverage is **report-only** (no threshold gate); a JUnit report and coverage summary are surfaced on the run.
+  - **`cross-platform`** (matrix: `windows-latest` + `macos-latest`, `fail-fast: false`): install/build/typecheck + server tests (`--no-file-parallelism`) + `vscode-test` (no xvfb — Electron is headless natively off Linux).
+  - **`ci-ok`** — aggregate gate (`needs: [build, cross-platform]`, `if: always()`). One stable check name for branch protection; collapses the matrix legs. Fails only if a needed job failed/was cancelled; **skipped jobs count as a pass**, so a `[ci skip]` push still satisfies it.
+- **Other workflows**: `audit.yml` (`npm audit` on prod deps, moderate+, + daily cron), `codeql.yml` (CodeQL `javascript-typescript`, security-extended → check **`Analyze (javascript-typescript)`**), `secret-scan.yml` (gitleaks CLI, `.gitleaks.toml` → check **`gitleaks`**), `license-headers.yml` (ESLint headers rule → check **`headers`**), `nightly.yml` (cron, nightly SDK), `changelog.yml` (**advisory, not required** — wants a `CHANGELOG.md` edit or the `no-changelog` label).
+- **Required checks** (branch protection on `main` + `develop`): `ci-ok`, `audit`, `gitleaks`, `headers`, `Analyze (javascript-typescript)`, `DCO`. `main` also requires a code-owner review (`.github/CODEOWNERS`, enforced for admins); `develop` merges are restricted to the `zowe-cli-administrators` team.
+- **The `typecheck` gate** (not just `build`): per-package `tsc -p tsconfig.json --noEmit` (covers tests + scripts) plus a root aggregator that builds `common` + `server` first (cross-package types resolve via built `dist`). Run `npm run typecheck` before pushing — tests can break types without breaking the build.
+- **Docs-drift gate**: `generate-docs` is deterministic (pinned mock clock, no commit hash); regenerating must not change the committed `docs/mcp-reference.md` / `vendor/zowe/docs/mcp-reference-vendor.md`. If CI fails here, run `npm run generate-docs` and commit the result.
+- **Cross-platform invariants** the matrix enforces (don't regress): USS command/path validation must pass `platform: null` to `hardstop-patterns` (USS targets z/OS Unix, not the CI host OS — see `command-validation.ts`); tests that open the extension's IPC channel must use `\\.\pipe\…` on Windows (see the `makePipePath` helper in `extension-client.test.ts`); `.gitattributes` enforces `eol=lf` so Windows checkouts don't CRLF-mangle shell scripts. Node version comes from **`.nvmrc` (Node 24)** everywhere.
+- **Dependencies are kept current by Dependabot** (`.github/dependabot.yml`: weekly npm, grouped dev/prod, + `github-actions`).
+
 ### Logging (MCP Server)
 
 - **Logger class**: `packages/zowe-mcp-server/src/log.ts` exports a `Logger` class with triple output: stderr (always), MCP protocol notifications (when connected), and VS Code extension pipe (when connected). Created as a singleton via `getLogger()` in `server.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+<!-- markdownlint-disable MD024 -->
+
+# Change Log
+
+All notable, user-facing changes to Zowe MCP (the `@zowe/mcp-server` package and
+the repository as a whole) are documented in this file. Per-component history
+for the VS Code extension lives in
+[`packages/zowe-mcp-vscode/CHANGELOG.md`](packages/zowe-mcp-vscode/CHANGELOG.md).
+
+Add an entry under **Unreleased** in the same PR that makes the change. PRs that
+don't warrant an entry (CI, chores, internal refactors, docs-only) can carry the
+`no-changelog` label instead — see
+[CONTRIBUTING.md](CONTRIBUTING.md#continuous-integration--branch-protection).
+
+## [Unreleased]
+
+_Nothing yet._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ development within Zowe MCP.
 - [AI-Assisted Development](#ai-assisted-development)
 - [Sign All of Your Git Commits](#sign-all-of-your-git-commits)
 - [Pull Request Guidelines](#pull-request-guidelines)
+- [Continuous Integration & Branch Protection](#continuous-integration--branch-protection)
 - [AI Evaluation Requirements](#ai-evaluation-requirements)
 - [Code Style](#code-style)
 - [Testing Guidelines](#testing-guidelines)
@@ -101,6 +102,40 @@ Consider the following when you interact with pull requests:
   Requirements](#ai-evaluation-requirements) checklist (see below).
 - Pull requests must include an [AI Usage](#ai-usage-disclosure-in-pull-requests)
   section describing how AI was used.
+
+## Continuous Integration & Branch Protection
+
+Both `main` and `develop` are protected. A pull request can be merged only when
+the required status checks are green and the branch rules are satisfied.
+
+### Required status checks
+
+| Check | Workflow | What it covers |
+| ----- | -------- | -------------- |
+| `ci-ok` | `ci.yml` | Aggregate gate over the Linux `build` job (lint, format, duplication, type-check, server tests + coverage, VS Code tests, pack, airgap, docs-drift, VSIX) **and** the `cross-platform` matrix (Windows + macOS build/type-check/tests). One stable name, so the CI jobs can be reorganized without touching branch protection. |
+| `audit` | `audit.yml` | `npm audit` on production dependencies (moderate+). |
+| `gitleaks` | `secret-scan.yml` | Secret scanning. |
+| `headers` | `license-headers.yml` | EPL-2.0 license header on every `.ts` file. |
+| `Analyze (javascript-typescript)` | `codeql.yml` | CodeQL static analysis (security-extended). |
+| `DCO` | (GitHub app) | Every commit is signed off (`git commit -s`). |
+
+`ci-ok` runs with `if: always()` and only fails if a required CI job actually
+failed or was cancelled. A `[ci skip]` push skips `build`/`cross-platform`, which
+counts as a pass — so trivial pushes still satisfy the check.
+
+The **Changelog** check (`changelog.yml`) is **advisory, not required**: it asks
+each PR to update a `CHANGELOG.md` (root or a package), or to carry the
+`no-changelog` label for changes that don't need an entry (CI, chore, docs,
+internal refactors). Record user-facing changes under **[Unreleased]** in the
+root [CHANGELOG.md](CHANGELOG.md).
+
+### Branch rules
+
+- **`main`** — requires a passing review from a code owner (see
+  [`.github/CODEOWNERS`](.github/CODEOWNERS)); rules are enforced for
+  administrators too.
+- **`develop`** — the integration branch; no review approval required, but only
+  members of the `zowe-cli-administrators` team can merge.
 
 ## AI Evaluation Requirements
 

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -269,33 +269,54 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
   - **`extension-client` tests used unix `.sock` paths** for their mock pipe
     (`listen EACCES` on Windows) — fixed with a `makePipePath()` helper that
     mirrors the production pipe-server (`\\.\pipe\…` on Windows).
-- [ ] **Not yet a required check** — promote `cross-platform` (and the security
-  checks) to required in Phase 6, once stable.
+- [x] **Promoted to required** in Phase 6 (PR-8) via the `ci-ok` aggregate, which
+  `needs: [build, cross-platform]`; the security checks are required individually.
 - [ ] Keep `.nvmrc` (Node 24) as the single source of truth; second LTS Node not
   added (the matrix exercises OS variation, which is the higher-value axis).
 
 ## Phase 6 — Gating & ergonomics
 
-- [ ] **Aggregate `ci-ok` gate job** that `needs:` all required jobs, so branch
-  protection requires one stable check name:
+**Done in PR-8.** The plan's original `ci-ok` snippet assumed every gate was a
+job in one workflow. Reality: the checks live in **5 workflows** — `ci.yml`
+(`build` + `cross-platform`), `audit.yml`, `codeql.yml`, `secret-scan.yml`,
+`license-headers.yml`. A `needs:`-based aggregate can only span jobs **within its
+own workflow**, so we chose **Option A**: `ci-ok` aggregates the `ci.yml` jobs
+into one stable name; the four security checks stay independent workflows
+(keeping their own cron schedules) and are required individually.
+
+- [x] **Aggregate `ci-ok` gate job** in `ci.yml`:
 
   ```yaml
   ci-ok:
-    needs: [build, format, lint, lint-md, dup, typecheck, test-server, test-vscode, audit, codeql]
+    name: ci-ok
+    needs: [build, cross-platform]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: |
-          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            exit 1
+          fi
   ```
 
-- [ ] **Enable branch protection** on `main` and `develop`: require `ci-ok` +
-  1 review + DCO + up-to-date branch. (Repo setting — document in
-  `CONTRIBUTING.md`.)
-- [ ] **Changelog check** (`changelog.yml`, `no-changelog` label escape hatch) —
-  pairs with later release-automation work.
-- [ ] **`[ci skip]` handling** — replicate the existing guard onto new jobs (or
-  hoist to a shared condition).
+  Collapses the `cross-platform` matrix legs into one check name, so CI jobs can
+  be added/renamed/sharded without churning branch protection — only a brand-new
+  *workflow* would.
+- [x] **Branch protection** now requires: `ci-ok`, `audit`, `gitleaks`,
+  `headers`, `Analyze (javascript-typescript)`, plus `DCO`. `main` additionally
+  requires a code-owner review and enforces rules for admins; `develop` merges
+  stay restricted to `zowe-cli-administrators`. Documented in `CONTRIBUTING.md`
+  (Continuous Integration & Branch Protection).
+- [x] **Changelog check** (`changelog.yml`, `no-changelog` label escape hatch) —
+  **advisory, not required.** A PR passes when it edits a `CHANGELOG.md` (root or
+  package) or carries `no-changelog`. Added a root `CHANGELOG.md` (Keep-a-Changelog
+  style, `[Unreleased]` section) as the repo-wide home; per-component history for
+  the extension stays in `packages/zowe-mcp-vscode/CHANGELOG.md`.
+- [x] **`[ci skip]` handling** — the only new `ci.yml` job, `ci-ok`, uses
+  `if: always()` so it runs even when `build`/`cross-platform` are guarded off by
+  `[ci skip]`; skipped jobs count as a pass, so `[ci skip]` commits still satisfy
+  the required check.
 
 ## Phase 7 — Speed & cost (after correctness)
 


### PR DESCRIPTION
Phase 6 — **Gating & ergonomics** of the [CI hardening plan](docs/ci-hardening-plan.md#phase-6--gating--ergonomics). Turns the gates built across phases 0–5 into one stable, enforceable branch-protection surface, and documents that surface for agents.

## What this PR contains

- **`ci-ok` aggregate gate** (`ci.yml`) — `needs: [build, cross-platform]`, `if: always()`. Gives branch protection **one stable check name** that collapses the `cross-platform` matrix legs, so CI jobs can be added/renamed/sharded without ever touching the protection config (only a brand-new *workflow* would). Fails only if a needed job **failed or was cancelled**; a skipped job (e.g. a `[ci skip]` push, where `build`/`cross-platform` are guarded off) counts as a **pass**, so those commits still satisfy the required check.
- **`changelog.yml`** — **advisory, not required.** A PR passes when it edits a `CHANGELOG.md` (root or package) or carries the **`no-changelog`** label (CI/chore/docs/refactor). `labeled`/`unlabeled` triggers re-run it the moment the label is toggled.
- **Root `CHANGELOG.md`** — Keep-a-Changelog style with an `[Unreleased]` section, as the repo-wide home. Per-component history for the extension stays in `packages/zowe-mcp-vscode/CHANGELOG.md`.
- **`CONTRIBUTING.md`** — new *Continuous Integration & Branch Protection* section: the required-checks table and the `main`/`develop` rules.
- **`AGENTS.md`** — new *Continuous Integration (GitHub Actions)* section so an agent reading it knows the gates it can trip (the `typecheck` gate, docs-drift gate, cross-platform invariants, required checks, Dependabot) before editing. Previously AGENTS.md documented only the local Cursor hooks, not the enforcing CI copy.
- **`docs/ci-hardening-plan.md`** — Phase 6 marked done; records the 5-workflow reality and the design choice.

## Design note — why not a single `needs:`-everything gate

The plan's original `ci-ok` snippet assumed all gates were jobs in one workflow. They aren't — they span **5 workflows**: `ci.yml` (`build` + `cross-platform`), `audit.yml`, `codeql.yml`, `secret-scan.yml`, `license-headers.yml`. A `needs:` aggregate can only span jobs **within its own workflow**. So **Option A**: `ci-ok` aggregates the `ci.yml` jobs; the four security checks remain independent workflows (keeping their own cron schedules) and are required **individually**.

## Branch protection (applied out of band)

After merge, `main` and `develop` will require: `ci-ok`, `audit`, `gitleaks`, `headers`, `Analyze (javascript-typescript)`, + `DCO`. `main` additionally requires a code-owner review (enforced for admins); `develop` merges stay restricted to `zowe-cli-administrators`. This repo-settings change is **not** part of this PR — it's applied by an admin once these check names are live on `develop`.

## Testing

- `npm run lint:md` → 0 errors (62 files), `npm run check-format` → clean.
- Both workflow files parse as valid YAML.
- Full CI green on the branch: `build`, `Cross-platform (windows-latest)`, `Cross-platform (macos-latest)`, and the new **`ci-ok`** all pass; `changelog`, `audit`, `gitleaks`, `headers`, `Analyze (javascript-typescript)`, `DCO` green. (This PR edits `CHANGELOG.md`, so the new `changelog` check passes on itself.)

## AI Usage
- **Tool**: Claude Code
- **Model**: Claude Opus 4.8
- **Scope**: All changes AI-generated under human direction (multi-workflow gate design confirmed by the maintainer).
- **Review**: Local lint/format/YAML validation; full CI watched green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)