### PR TITLE
chore(deps): clear js-yaml + markdown-it moderate advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/minimatch/-/minimatch-3.1.5.tgz",
@@ -2195,6 +2218,29 @@
         "text-table": "^0.2.0"
       }
     },
+    "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@textlint/linter-formatter/node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/lodash/-/lodash-4.18.1.tgz",
@@ -3365,6 +3411,54 @@
         "node": ">=10"
       }
     },
+    "node_modules/@vscode/vsce/node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/markdown-it/node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/@vscode/vsce/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/minimatch/-/minimatch-3.1.5.tgz",
@@ -3477,11 +3571,79 @@
         "node": ">=18"
       }
     },
+    "node_modules/@zowe/imperative/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@zowe/imperative/node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@zowe/imperative/node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@zowe/imperative/node_modules/markdown-it/node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/@zowe/imperative/node_modules/which": {
       "version": "4.0.0",
@@ -6981,6 +7143,7 @@
       "version": "4.1.1",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7304,6 +7467,7 @@
       "version": "5.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -7519,6 +7683,7 @@
       "version": "14.1.1",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -8512,6 +8677,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -9803,6 +9991,29 @@
         "js-yaml": "^4.1.1",
         "json5": "^2.2.3",
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/rc-config-loader/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/rc/node_modules/strip-json-comments": {
@@ -12213,6 +12424,28 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "packages/zowe-mcp-evals/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "packages/zowe-mcp-evals/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -12494,6 +12727,28 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/zowe-mcp-server/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "packages/zowe-mcp-server/node_modules/path-to-regexp": {
       "version": "8.4.0",


### PR DESCRIPTION
Two **moderate** advisories were published (2026-06-16) against transitive **production** dependencies, turning the `audit` gate (and the daily cron) red repo-wide:

- **`js-yaml` ≤4.1.1** — quadratic-complexity DoS in merge-key handling ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68))
- **`markdown-it` ≤14.1.1** — quadratic-complexity DoS in the smartquotes rule ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq))

Both have **non-breaking** fixes. This is a **lockfile-only** change — a targeted `npm update js-yaml markdown-it` (no `package.json` edits) bumps the production-reachable copies to **js-yaml 4.2.0** / **markdown-it 14.2.0**.

After this, `npm audit --omit=dev --audit-level=moderate` reports only the **5 known `@ai-sdk/*` lows** (below the moderate gate; left to Dependabot per `docs/ci-hardening-plan.md`).

## Testing
- `npm audit --omit=dev --audit-level=moderate` → exits 0 (5 low, 0 moderate+).
- `zowex-sdk` `file:` lockfile entry verified intact.
- No `package.json` change; no production source change.

## AI Usage
- **Tool**: Claude Code · **Model**: Claude Opus 4.8
- **Scope**: AI-performed targeted dependency bump under human direction.
- **Review**: Local audit verification; CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)