### PR TITLE
ci: upload ESLint findings to code scanning (SARIF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ on:
         required: false
         type: string
 
-# Least privilege: the sticky PR comment needs pull-requests write and the
-# JUnit test reporter needs checks write; everything else reads.
+# Least privilege: the sticky PR comment needs pull-requests write, the JUnit
+# test reporter needs checks write, and the ESLint SARIF upload needs
+# security-events write; everything else reads.
 permissions:
   contents: read
   pull-requests: write
   checks: write
+  security-events: write
 
 # Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
 concurrency:
@@ -100,6 +102,23 @@ jobs:
         run: npm run typecheck --workspaces --if-present
 
       - run: npm run lint
+
+      # Emit an ESLint SARIF report and upload it to code scanning, so lint
+      # findings appear in the Security tab and as inline PR annotations. The
+      # hard gate above (`npm run lint`, --max-warnings 0) is what blocks the
+      # build; this is visibility-only and never fails the job. Runs even if the
+      # gate failed (!cancelled) so the annotations show up exactly when needed.
+      - name: ESLint SARIF report
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: npm run lint:sarif
+      - name: Upload ESLint SARIF
+        # security-events:write is unavailable to fork-PR tokens — skip there.
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: eslint-results.sarif
+          category: eslint
 
       # Server tests with coverage (report-only — no threshold gate) and a
       # JUnit file for the PR checks UI. e2e suites self-skip without their

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ db2cli.trc
 # Manual QA: VS Code profile export ZIPs (may contain secrets)
 manual-test-workspace/profile-exports/*.zip
 report/jscpd-report.json
+
+# ESLint SARIF report (generated in CI, uploaded to code scanning)
+eslint-results.sarif

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -148,9 +148,13 @@ No new tools; make `ci.yml` robust.
 - [x] `timeout-minutes` on the job (30).
 - [x] Least-privilege `permissions` (`contents: read` + `pull-requests: write`).
 - [x] npm caching via `setup-node` (`cache: npm`).
-- [ ] Pin actions to SHAs — deferred to **Phase 4 Dependabot**; majors were
-  already bumped to Node-24-ready versions in the carry-overs PR
-  (checkout v6, setup-node v6, upload-artifact v7, sticky-comment v3).
+- [x] **Action pinning — decided: tag-pinning, not SHAs.** Actions stay pinned to
+  major tags (checkout v6, setup-node v6, upload-artifact v7, sticky-comment v3,
+  codeql-action v3) and the Dependabot `github-actions` ecosystem (Phase 4) keeps
+  them current. Full-SHA pinning was considered and **not adopted** — the marginal
+  supply-chain hardening isn't worth the readability/maintenance cost here, and
+  Dependabot would rewrite the SHAs anyway. Revisit only if we adopt OpenSSF
+  Scorecard, which scores SHA-pinning.
 
 ## Phase 2 — Enforce existing quality scripts
 
@@ -274,8 +278,9 @@ Today only `test:server` runs. Add the rest, tiered by infra needs.
     mirrors the production pipe-server (`\\.\pipe\…` on Windows).
 - [x] **Promoted to required** in Phase 6 (PR-8) via the `ci-ok` aggregate, which
   `needs: [build, cross-platform]`; the security checks are required individually.
-- [ ] Keep `.nvmrc` (Node 24) as the single source of truth; second LTS Node not
-  added (the matrix exercises OS variation, which is the higher-value axis).
+- [x] **`.nvmrc` (Node 24) is the single source of truth** (settled decision); a
+  second LTS Node was deliberately not added — the matrix exercises OS variation,
+  which is the higher-value axis.
 
 ## Phase 6 — Gating & ergonomics
 

--- a/docs/ci-hardening-plan.md
+++ b/docs/ci-hardening-plan.md
@@ -373,8 +373,15 @@ Deferred work spun off from the phases above, so it isn't lost:
   `schemas/plugin-tools.schema.json` with `ajv`; runs in the normal test job on
   every OS. `vendor/zowe/cli-bridge-plugins/db2-tools.yaml` passes clean (no
   drift).
-- **ESLint SARIF → code scanning** (from Phase 2) — optional: emit ESLint SARIF
-  and upload so lint findings annotate PRs inline.
+- ✅ **ESLint SARIF → code scanning** (from Phase 2) — **done** (PR #26). The
+  `build` job runs `npm run lint:sarif` (`@microsoft/eslint-formatter-sarif`)
+  and uploads the result via `github/codeql-action/upload-sarif`, so lint
+  findings surface in the Security tab and as inline PR annotations. It's
+  visibility-only (`continue-on-error`, runs on `!cancelled()`); the existing
+  `npm run lint` (`--max-warnings 0`) remains the hard gate. Inline
+  `// eslint-disable` directives are emitted with SARIF `suppressions`, so code
+  scanning shows them as suppressed rather than active alerts. Upload is skipped
+  for fork PRs (no `security-events: write` on their token).
 
 ## Reference: what zowex runs (for comparison)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@vitest/eslint-plugin": "^1.6.7",
         "@wasm-fmt/shfmt": "^0.2.7",
         "cloc": "^2.6.0",
@@ -1365,6 +1366,360 @@
         "reprism": "^0.0.11",
         "spark-md5": "^3.0.2"
       }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif": {
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@microsoft/eslint-formatter-sarif/-/eslint-formatter-sarif-3.1.0.tgz",
+      "integrity": "sha512-/mn4UXziHzGXnKCg+r8HGgPy+w4RzpgdoqFuqaKOqUVBT5x2CygGefIrO4SusaY7t0C4gyIWMNu6YQT6Jw64Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint": "^8.9.0",
+        "jschardet": "latest",
+        "lodash": "^4.17.14",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/@humanwhocodes/config-array/node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/file-entry-cache/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/file-entry-cache/node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/file-entry-cache/node_modules/flat-cache/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "dev": true,
+      "license": "LGPL-2.1+",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "inspector": "npx @modelcontextprotocol/inspector node packages/zowe-mcp-server/dist/index.js --stdio",
     "lint:fix": "eslint --fix \"packages/**/*.ts\" --max-warnings 0",
     "lint": "eslint \"packages/**/*.ts\" --max-warnings 0",
+    "lint:sarif": "eslint \"packages/**/*.ts\" -f @microsoft/eslint-formatter-sarif -o eslint-results.sarif",
     "typecheck": "npm run build -w packages/zowe-mcp-common && npm run build -w @zowe/mcp-server && npm run typecheck --workspaces --if-present",
     "lint:md": "markdownlint-cli2",
     "markdownlint:fix": "markdownlint-cli2 --fix",
@@ -56,6 +57,7 @@
     "local-registry:wipe-publish-dev": "bash scripts/local-registry-wipe-publish-dev.sh"
   },
   "devDependencies": {
+    "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@vitest/eslint-plugin": "^1.6.7",
     "@wasm-fmt/shfmt": "^0.2.7",
     "cloc": "^2.6.0",


### PR DESCRIPTION
The last tracked follow-up from the [CI hardening plan](docs/ci-hardening-plan.md#follow-ups-tracked). Surfaces ESLint findings in **Security → Code scanning** and as inline PR annotations.

## What it does
- The `build` job runs `npm run lint:sarif` (`@microsoft/eslint-formatter-sarif`) and uploads the result via `github/codeql-action/upload-sarif` (category `eslint`).
- **Visibility-only** — `continue-on-error` + `if: !cancelled()`, so it never fails the build and still uploads when the hard gate (`npm run lint`, `--max-warnings 0`) failed (exactly when you want the annotations). The hard gate remains the thing that blocks.
- Inline `// eslint-disable` directives are emitted with SARIF **`suppressions`**, so code scanning shows them as *suppressed*, not active alerts — matching the gate's 0 active problems. (Today: 0 active, 26 suppressed.)
- Adds `security-events: write` (for the upload) and the dev-only formatter dep; **skips upload on fork PRs** (their token has no `security-events` write).
- `eslint-results.sarif` is gitignored.

Also marks the **ESLint-SARIF** follow-up done in the plan (Windows-tests and plugin-schema follow-ups were already closed) — so the tracked follow-ups list is now empty.

## Testing
- `npm run lint:sarif` → valid SARIF 2.1.0 (ESLint driver); 0 active results, 26 suppressed (all `kind: inSource`).
- `npm run lint` (gate), `lint:md`, `check-format` → clean; `ci.yml` parses as valid YAML.
- The Security-tab upload is exercised by this PR's own `build` run.

## AI Usage
- **Tool**: Claude Code · **Model**: Claude Opus 4.8
- **Scope**: AI-implemented under human direction.
- **Review**: Local validation + CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)