### PR TITLE
Release v0.10.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ don't warrant an entry (CI, chores, internal refactors, docs-only) can carry the
 
 ## [Unreleased]
 
+## [0.10.0-rc.1] - 2026-08-12
+
 ### Added
 
 - **Copilot Chat e2e: VS Code 1.132 compatibility.** The apparent 1.132

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@ Ideas inspired by [Gestell-AI/zowe-mcp](https://github.com/Gestell-AI/zowe-mcp) 
 ## Security / Infrastructure
 
 - **Pipe path security**: Review `/tmp` usage for named pipes — ensure the path is secure and the name is really unique (e.g. `/tmp/zowe-mcp-<workspaceId>.sock`).
-- **Move zowex SDK tarball out of git**: `resources/zowe-zowex-for-zowe-sdk-*.tgz` is a binary blob committed to the repo (PR feedback: it slows down every fetch/clone, and each version bump adds another copy to history forever). Distribute via an npm registry or GitHub release asset instead and fetch at install time (with checksum pinning for air-gapped installs); consider whether existing blobs warrant history cleanup (BFG/filter-repo) or Git LFS, coordinated with all forks/PRs since it rewrites history.
+- ✅ **Move zowex SDK tarball out of git**: Done in [#64](https://github.com/zowe/zowe-mcp/pull/64) — the tarball is no longer committed. `resources/zowex-pin.json` records the exact build (url, SHA-256, datestamp, upstream commit) and `scripts/sdk-switch.js pin` stages it on demand into a gitignored `resources/`, verifying the checksum; CI stages the pin before every install and releases archive the tarball plus a `zowex-provenance.json` so a published version stays reproducible after upstream prunes its nightly snapshots. **Still open**: history cleanup — six blobs remain in git history, and removing them needs a rewrite (BFG/filter-repo) coordinated with all forks and open PRs.
 
 ## Testing
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -2,7 +2,7 @@
 
 # Zowe MCP Server Reference
 
-> Auto-generated from the MCP server (v0.10.0-dev). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
+> Auto-generated from the MCP server (v0.10.0-rc.1). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
 
 This document describes all [Context](#context), [Data Sets](#data-sets), [USS](#uss), [TSO](#tso), [System Information](#system-information), [Certificates](#certificates), [Jobs](#jobs), [Local Files](#local-files), [Other](#other), [db2 CLI Plugin Tools](#db2-cli-plugin-tools), [Tool Reference](#tool-reference), [Capability Tiers](#capability-tiers), [Prompts](#prompts), [Resource Templates](#resource-templates) provided by the Zowe MCP Server.
 
@@ -225,7 +225,7 @@ Return the Zowe MCP server info (version, backend, components) and the current s
 {
   "server": {
     "name": "Zowe MCP Server",
-    "version": "0.10.0-dev",
+    "version": "0.10.0-rc.1",
     "description": "MCP server providing tools for z/OS systems including data sets, jobs, and UNIX System Services",
     "components": [
       "context",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zowe-mcp",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zowe-mcp",
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "workspaces": [
         "packages/*"
       ],
@@ -10941,11 +10941,11 @@
       "link": true
     },
     "packages/zowe-mcp-common": {
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "license": "EPL-2.0"
     },
     "packages/zowe-mcp-e2e": {
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "license": "EPL-2.0",
       "bin": {
         "fake-model-server": "dist/cli.js"
@@ -12020,7 +12020,7 @@
       }
     },
     "packages/zowe-mcp-evals": {
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "license": "EPL-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.33",
@@ -13610,7 +13610,7 @@
     },
     "packages/zowe-mcp-server": {
       "name": "@zowe/mcp-server",
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "license": "EPL-2.0",
       "dependencies": {
         "@faker-js/faker": "^10.5.0",
@@ -15626,12 +15626,12 @@
       }
     },
     "packages/zowe-mcp-vscode": {
-      "version": "0.10.0-dev",
+      "version": "0.10.0-rc.1",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/imperative": "^8.34.0",
-        "@zowe/mcp-server": "0.10.0-dev",
+        "@zowe/mcp-server": "0.10.0-rc.1",
         "zowe-mcp-common": "*"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowe-mcp",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "private": true,
   "description": "Zowe MCP - Model Context Protocol server and VS Code extension for z/OS",
   "workspaces": [

--- a/packages/zowe-mcp-common/package.json
+++ b/packages/zowe-mcp-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowe-mcp-common",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "description": "Shared utilities for Zowe MCP packages",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/zowe-mcp-e2e/__tests__/e2e/vscode-132-experiments.e2e.test.ts
+++ b/packages/zowe-mcp-e2e/__tests__/e2e/vscode-132-experiments.e2e.test.ts
@@ -25,7 +25,6 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { Page } from 'playwright';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
@@ -45,19 +44,12 @@ import {
   cleanupPortableProfile,
   createPortableProfile,
   installExtension,
+  resolveVsixPath,
   type PortableProfile,
 } from '../../src/portable-profile.js';
 import { byokOllamaSettings, zoweFilesystemMockSettings } from '../../src/vscode-settings.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const VSIX_PATH = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'zowe-mcp-vscode',
-  'zowe-mcp-vscode-0.10.0-dev.vsix'
-);
+const VSIX_PATH = resolveVsixPath();
 
 const SUITE_TIMEOUT_MS = 240_000;
 

--- a/packages/zowe-mcp-e2e/__tests__/e2e/vscode-copilot-ollama.e2e.test.ts
+++ b/packages/zowe-mcp-e2e/__tests__/e2e/vscode-copilot-ollama.e2e.test.ts
@@ -29,7 +29,6 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   closeVsCode,
@@ -48,18 +47,11 @@ import {
   createPortableProfile,
   installExtension,
   type PortableProfile,
+  resolveVsixPath,
 } from '../../src/portable-profile.js';
 import { byokOllamaSettings, zoweFilesystemMockSettings } from '../../src/vscode-settings.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const VSIX_PATH = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'zowe-mcp-vscode',
-  'zowe-mcp-vscode-0.10.0-dev.vsix'
-);
+const VSIX_PATH = resolveVsixPath();
 
 const OLLAMA_URL = process.env.ZOWE_E2E_OLLAMA_URL ?? 'http://localhost:11434';
 const OLLAMA_MODEL = process.env.ZOWE_E2E_OLLAMA_MODEL ?? 'phi4-mini:latest';

--- a/packages/zowe-mcp-e2e/__tests__/e2e/vscode-copilot.e2e.test.ts
+++ b/packages/zowe-mcp-e2e/__tests__/e2e/vscode-copilot.e2e.test.ts
@@ -29,7 +29,6 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   closeVsCode,
@@ -52,6 +51,7 @@ import {
   cleanupPortableProfile,
   createPortableProfile,
   installExtension,
+  resolveVsixPath,
   type PortableProfile,
 } from '../../src/portable-profile.js';
 import {
@@ -61,15 +61,7 @@ import {
   zoweNativeMockZosSettings,
 } from '../../src/vscode-settings.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const VSIX_PATH = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'zowe-mcp-vscode',
-  'zowe-mcp-vscode-0.10.0-dev.vsix'
-);
+const VSIX_PATH = resolveVsixPath();
 
 const SUITE_TIMEOUT_MS = 240_000;
 

--- a/packages/zowe-mcp-e2e/package.json
+++ b/packages/zowe-mcp-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowe-mcp-e2e",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "description": "Deterministic fake LLM server for VS Code Copilot Chat BYOK end-to-end testing",
   "private": true,
   "type": "module",

--- a/packages/zowe-mcp-e2e/src/portable-profile.ts
+++ b/packages/zowe-mcp-e2e/src/portable-profile.ts
@@ -24,6 +24,7 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /** Settings every profile gets unless explicitly overridden. */
 const DEFAULT_SETTINGS: Record<string, unknown> = {
@@ -237,6 +238,25 @@ export function updateSettings(profile: PortableProfile, patch: Record<string, u
     unknown
   >;
   fs.writeFileSync(profile.settingsPath, JSON.stringify({ ...current, ...patch }, null, 2));
+}
+
+/**
+ * Absolute path to the built extension .vsix.
+ *
+ * The version is read from the extension's package.json rather than hardcoded: `npm run package`
+ * names the file after the current version, so a release branch (e.g. 0.10.0-rc.1) produces a
+ * different filename than a development one. Hardcoding `-dev` here meant every release PR
+ * failed this suite with "vsix not found".
+ */
+export function resolveVsixPath(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // src/ and dist/ are both one level under the package root, so '..', '..' reaches packages/.
+  const extensionDir = path.resolve(here, '..', '..', 'zowe-mcp-vscode');
+  const pkg = JSON.parse(fs.readFileSync(path.join(extensionDir, 'package.json'), 'utf8')) as {
+    name: string;
+    version: string;
+  };
+  return path.join(extensionDir, `${pkg.name}-${pkg.version}.vsix`);
 }
 
 /**

--- a/packages/zowe-mcp-evals/package.json
+++ b/packages/zowe-mcp-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowe-mcp-evals",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "description": "AI evaluations for Zowe MCP data set/member tools",
   "type": "module",
   "main": "dist/run.js",

--- a/packages/zowe-mcp-server/package.json
+++ b/packages/zowe-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/mcp-server",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "description": "Zowe MCP Server - Model Context Protocol server providing tools for z/OS",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/zowe-mcp-server/server.json
+++ b/packages/zowe-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.zowe/zowe-mcp-server",
   "title": "Zowe MCP Server",
   "description": "MCP server providing AI tools for z/OS — data sets, jobs, and USS via SSH or mock filesystem.",
-  "version": "0.8.0",
+  "version": "0.10.0-rc.1",
   "repository": {
     "url": "https://github.com/zowe/zowe-mcp",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@zowe/mcp-server",
-      "version": "0.8.0",
+      "version": "0.10.0-rc.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/zowe-mcp-vscode/CHANGELOG.md
+++ b/packages/zowe-mcp-vscode/CHANGELOG.md
@@ -6,8 +6,24 @@ All notable changes to the Zowe MCP extension will be documented in this file.
 
 ## Recent Changes
 
-- **System tools**: A new group of system tools has been introduced to allow the user to list APF Authorized data sets, link list data sets, proclib data sets, and view system log information.  [#45](https://github.com/zowe/zowe-mcp/pull/45)
+## `0.10.0-rc.1`
+
+### New features and enhancements
+
+- **System tools**: A new group of system tools has been introduced to allow the user to list APF Authorized data sets, link list data sets, proclib data sets, and view system log information. [#45](https://github.com/zowe/zowe-mcp/pull/45)
 - **Certificate tools**: A new group of certificate and key ring tools has been introduced to show, connect, delete, export, import, set the ring default, change trust status, rename, and refresh certificates on the z/OS security database (RACF, ACF2, or Top Secret). [#45](https://github.com/zowe/zowe-mcp/pull/45)
+- **SSH key authentication**: The Zowe Remote SSH backend can now authenticate with an SSH private key, preferred over a password, falling back to password automatically when no usable key is found. [#44](https://github.com/zowe/zowe-mcp/pull/44)
+- **A system is selected automatically**: When no system has been chosen and exactly one is configured, tools now use it instead of returning an error.
+- **Existing `zowex` on `$PATH` is preferred**: If the z/OS server binary is already installed and on the path, it is used instead of deploying a private copy. [#56](https://github.com/zowe/zowe-mcp/pull/56)
+
+### Bug fixes
+
+- **Server deploy could silently corrupt when the deploy directory ran out of space**, surfacing much later as a confusing load failure. Space is now checked before deploying, and a truncated binary is detected and redeployed automatically. [#56](https://github.com/zowe/zowe-mcp/pull/56)
+
+### Other
+
+- **Data trust boundary**: Server instructions now tell the assistant to treat z/OS content as data, not instructions, reducing prompt-injection risk from mainframe file contents.
+- **Model evaluation suite expanded** (78 → 147 questions), adding coverage for the new system and certificate tools and for multi-turn conversations, support for Anthropic and OpenAI providers, and an opt-in Claude Code integration smoke that drives the real `claude` CLI against the server. On the newest tool sets, `qwen3.6-35b-a3b` scored 100% (system 55/55, certificates 65/65, multi-turn 20/20 across five repetitions each) and `gemini-2.5-flash` was close behind at ~94%. Running the suite against a model is a good way to judge how well it drives the Zowe MCP tools — see the [eval scoreboard](https://github.com/zowe/zowe-mcp/blob/main/docs/eval-scoreboard.md). [#48](https://github.com/zowe/zowe-mcp/pull/48), [#58](https://github.com/zowe/zowe-mcp/pull/58)
 
 ## `0.9.0`
 

--- a/packages/zowe-mcp-vscode/package.json
+++ b/packages/zowe-mcp-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "zowe-mcp-vscode",
   "displayName": "Zowe MCP",
   "description": "Zowe MCP Server for z/OS - provides AI tools for data sets, jobs, and UNIX System Services.",
-  "version": "0.10.0-dev",
+  "version": "0.10.0-rc.1",
   "publisher": "Zowe",
   "author": "Zowe",
   "license": "EPL-2.0",
@@ -369,7 +369,7 @@
   "dependencies": {
     "@zowe/imperative": "^8.34.0",
     "zowe-mcp-common": "*",
-    "@zowe/mcp-server": "0.10.0-dev"
+    "@zowe/mcp-server": "0.10.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/vendor/zowe/docs/mcp-reference-vendor.md
+++ b/vendor/zowe/docs/mcp-reference-vendor.md
@@ -2,7 +2,7 @@
 
 # Zowe CLI Plugin Tools Reference
 
-> Auto-generated from the Zowe MCP server (v0.10.0-dev). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
+> Auto-generated from the Zowe MCP server (v0.10.0-rc.1). Do not edit manually — run `npx @zowe/mcp-server generate-docs` to regenerate.
 
 > For core Zowe MCP tools, see [docs/mcp-reference.md](../../../docs/mcp-reference.md).
 


### PR DESCRIPTION
Prerelease rehearsal of the CI release pipeline, per [docs/release-process.md](https://github.com/zowe/zowe-mcp/blob/main/docs/release-process.md#rehearsal-paths). Merging this PR **is** the release approval — CI does the rest.

## What merging this triggers

`release.yml` sees a clean, untagged version on `main` → `mode=publish`, `is-prerelease=true`:

stage pinned zowex SDK → `npm ci` → extract release notes → Octorelease (`exec` builds and packages, `github` tags and drafts) → tag `v0.10.0-rc.1` → notes applied and the draft flipped live with `--prerelease`.

The dev-bump PR step is deliberately skipped for prereleases, so **`main` will sit at `0.10.0-rc.1`** afterwards. A follow-up PR is needed to move to `0.10.0` or back to `-dev`.

## Assets

This is the first release to carry the archived zowex SDK, from #64:

- `zowe-mcp-vscode-0.10.0-rc.1.vsix`
- `zowe-mcp-server-0.10.0-rc.1.tgz`
- `zowe-zowex-for-zowe-sdk-0.7.1-2026-08-12-083747.tgz` — the exact SDK build this was compiled and tested against
- `zowex-provenance.json` — SDK sha256, `server.pax.Z` sha256, upstream zowex commit
- `docs/mcp-reference.md`, `zowe-mcp-slides.pdf`

## Contents

Version bumped across all workspaces and `server.json`; both changelogs rolled; `docs/mcp-reference.md` and the vendor copy regenerated (version stamp only).

Slides were **not** re-exported — nothing under `presentations/` has changed since the PDF was last built (`44d81bc`), so the deck is already in sync.

`TODO.md` marks "Move zowex SDK tarball out of git" done (#64), keeping the history-cleanup half explicitly open.

## Verified locally

- `npm run test:all` green across all workspaces: 11 + 143 + 932 (113 skipped) + 18
- `npm run lint:md`, `npm run check-format` clean
- `sdk-switch.js pin --no-install` → `npm ci` → `extract-release-notes.js 0.10.0-rc.1` — the exact release.yml sequence

## Reviewer note

`scripts/set-version.js` does not update `package-lock.json`, so the lockfile keeps the old version and `npm ci` can drift out of sync. I ran `npm install` to sync it here; worth teaching the script to do this before the real 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)