### PR TITLE
fix(release): pass the version to Octorelease explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,11 +137,21 @@ jobs:
       # build + packaging; the github plugin then creates the vX.Y.Z tag and
       # a DRAFT release with the assets (publishRelease is off in
       # release.config.js — the next step publishes it).
+      #
+      # new-version is passed explicitly: without it, Octorelease derives the
+      # version from `git describe` on v* tags, and no release tag is an
+      # ancestor of main (the pre-#30 history holds them all), so it falls
+      # back to 0.0.0 — the v0.10.0-rc.1 rehearsal produced a draft tagged
+      # v0.0.0 and the publish step then failed with "release not found".
+      # The release PR already carries the reviewed version in package.json;
+      # this step must release exactly that, never an inferred one.
       - name: Run Octorelease
         if: steps.version.outputs.mode == 'publish'
         uses: zowe-actions/octorelease@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        with:
+          new-version: ${{ steps.version.outputs.version }}
 
       # Set the human-reviewed notes on the draft, then publish it — one
       # atomic edit. Doing notes-before-publish means a failure here leaves

--- a/packages/zowe-mcp-server/__tests__/release-workflow-contract.test.ts
+++ b/packages/zowe-mcp-server/__tests__/release-workflow-contract.test.ts
@@ -1,0 +1,95 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/**
+ * Contract tests for .github/workflows/release.yml.
+ *
+ * The publish pipeline only runs after a release PR merges to main, so a broken invariant
+ * surfaces at the worst possible time — during a real release, after the approval decision.
+ * These assertions pin the parts that have actually bitten:
+ *
+ * The v0.10.0-rc.1 rehearsal failed because Octorelease was left to infer the version via
+ * `git describe` on v* tags. No release tag is an ancestor of main (the pre-#30 promoted
+ * history holds them all), so it fell back to 0.0.0, created a draft tagged v0.0.0, and the
+ * publish step failed with "release not found" for v0.10.0-rc.1. The fix is passing
+ * `new-version` explicitly from the same source the rest of the workflow uses.
+ */
+
+import { load as yamlLoad } from 'js-yaml';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowPath = join(__dirname, '..', '..', '..', '.github', 'workflows', 'release.yml');
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+function loadReleaseSteps(): WorkflowStep[] {
+  const doc = yamlLoad(readFileSync(workflowPath, 'utf-8')) as {
+    jobs: Record<string, { steps: WorkflowStep[] }>;
+  };
+  const job = doc.jobs.release;
+  expect(job, 'release.yml must define a `release` job').toBeDefined();
+  return job.steps;
+}
+
+function findStep(steps: WorkflowStep[], name: string): WorkflowStep {
+  const step = steps.find(s => s.name === name);
+  expect(step, `release job must have a step named "${name}"`).toBeDefined();
+  return step as WorkflowStep;
+}
+
+describe('release workflow contract', () => {
+  const steps = loadReleaseSteps();
+
+  it('passes the workflow-determined version to Octorelease explicitly', () => {
+    const octorelease = findStep(steps, 'Run Octorelease');
+
+    // Without this input Octorelease falls back to `git describe`, which yields 0.0.0 on
+    // this repo because no release tag is an ancestor of main.
+    expect(octorelease.with?.['new-version']).toBe('${{ steps.version.outputs.version }}');
+  });
+
+  it('gates Octorelease on publish mode so dry runs never tag', () => {
+    const octorelease = findStep(steps, 'Run Octorelease');
+
+    expect(octorelease.if).toBe("steps.version.outputs.mode == 'publish'");
+  });
+
+  it('edits the same tag Octorelease creates (v + the same version output)', () => {
+    // The rehearsal failure was precisely these two disagreeing: Octorelease created
+    // v0.0.0 while this step edited v0.10.0-rc.1. Both must derive from
+    // steps.version.outputs.version.
+    const publish = findStep(steps, 'Publish release with notes');
+
+    expect(publish.run).toContain('gh release edit "v${{ steps.version.outputs.version }}"');
+  });
+
+  it('stages the pinned zowex SDK before npm ci', () => {
+    // The SDK tarball is not committed (#64); npm ci fails ENOENT on a cold cache when the
+    // file: target is missing, so the staging step must come first.
+    const names = steps.map(s => s.name);
+    const stageIdx = names.indexOf('Stage pinned zowex SDK');
+    const installIdx = names.indexOf('Install dependencies (npm ci)');
+
+    expect(stageIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(stageIdx).toBeLessThan(installIdx);
+  });
+});

--- a/packages/zowe-mcp-server/__tests__/release-workflow-contract.test.ts
+++ b/packages/zowe-mcp-server/__tests__/release-workflow-contract.test.ts
@@ -52,7 +52,7 @@ function loadReleaseSteps(): WorkflowStep[] {
 function findStep(steps: WorkflowStep[], name: string): WorkflowStep {
   const step = steps.find(s => s.name === name);
   expect(step, `release job must have a step named "${name}"`).toBeDefined();
-  return step as WorkflowStep;
+  return step!;
 }
 
 describe('release workflow contract', () => {


### PR DESCRIPTION
The v0.10.0-rc.1 rehearsal (#65) failed at the final step. Root cause: Octorelease, given no `new-version`, infers the version via `git describe --tags` — and **no release tag is an ancestor of `main`** (the pre-#30 promoted history holds `v0.8.0`/`v0.9.0`), so it fell back to `0.0.0`, created a draft tagged `v0.0.0` (with all six assets correctly attached), and `Publish release with notes` failed with `release not found` for `v0.10.0-rc.1`.

**Not prerelease-specific** — the real 0.10.0 would have failed identically. This was the rehearsal earning its keep.

## Fix

```yaml
with:
  new-version: ${{ steps.version.outputs.version }}
```

Verified against octorelease source that a non-empty `new-version` overrides the describe path (`core/src/inputs.ts` returns `undefined` for empty string; `verifyConditions` in `core/src/utils.ts` uses the input when set). The pipeline's design is that the release PR carries the reviewed version — the workflow should release exactly that, never an inferred one. Same pattern `zowe/zowex` uses.

## Test

`release-workflow-contract.test.ts` parses the workflow and pins:
- the `new-version` wiring (the regression) — mutation-checked: removing the `with:` block fails it
- the publish-mode gate on Octorelease
- that the publish step edits the same `v` + version tag Octorelease creates — the invariant that actually broke was these two disagreeing
- the stage-pinned-SDK-before-`npm ci` ordering from #64

## Cleanup already done

The mistagged `v0.0.0` draft is deleted (drafts create no tag, so nothing else to clean). No `v0.10.0-rc.1` tag or release exists; `main` still carries version `0.10.0-rc.1`, so **merging this re-arms the release** — the next push to main with the fix lands should publish rc.1 properly. Also noting: everything else in the rehearsal worked, including the first CI run of the SDK archiving (hashes matched local: SDK `85c280e1…`, pax `195c7a9d…`).

Filed as part of the release-process findings in #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)