### PR TITLE
fix(release): make dev-version bump PR pass changelog and docs-drift checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,9 +203,19 @@ jobs:
           node scripts/set-version.js "$NEXT_VERSION"
           # set-version.js also syncs package-lock.json (zowe-mcp#66 finding 1), so stage it too.
           git add -u -- package.json package-lock.json packages/*/package.json packages/zowe-mcp-server/server.json
+
+          # The reference docs embed the server version in their header, so the
+          # version bump alone leaves them stale and fails the ci.yml docs-drift
+          # gate (`git diff --exit-code docs/mcp-reference.md
+          # vendor/zowe/docs/mcp-reference-vendor.md`). Regenerate and stage them
+          # in the same commit.
+          npm run generate-docs
+          git add -- docs/mcp-reference.md vendor/zowe/docs/mcp-reference-vendor.md
+
           git commit -s -m "chore: set development version to ${NEXT_VERSION}"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${BRANCH}"
 
           gh pr create --base main --head "$BRANCH" \
             --title "chore: set development version to ${NEXT_VERSION}" \
-            --body "Automated post-release version bump after v${VERSION}. Sets the development version to ${NEXT_VERSION} so main is ready for the next development cycle. Please also sync this onto \`develop\`."
+            --body "Automated post-release version bump after v${VERSION}. Sets the development version to ${NEXT_VERSION} so main is ready for the next development cycle. Please also sync this onto \`develop\`." \
+            --label no-changelog


### PR DESCRIPTION
## Summary
- The automated post-release dev-version bump PR (e.g. #72) was failing two required checks:
  - **changelog**: it only bumps versions, so it needs the `no-changelog` label — now applied automatically by `gh pr create --label no-changelog`.
  - **build**: `docs/mcp-reference.md` and `vendor/zowe/docs/mcp-reference-vendor.md` embed the server version in their header. Bumping the version without regenerating the docs left them stale, failing ci.yml's docs-drift gate. The bump step now runs `npm run generate-docs` and stages the regenerated docs in the same commit.
- Also fixed PR #72 directly (labeled `no-changelog`, pushed a commit regenerating its stale docs) so it's unblocked now, ahead of this workflow fix landing.

## Test plan
- [x] Regenerated docs locally on the #72 branch and diffed against what CI's `git diff --exit-code` step flagged — identical version-string-only diff.
- [x] Next real release will exercise the updated workflow step end-to-end.