### PR TITLE
ci(dependabot): auto-apply no-changelog label; twice-monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   # always raised individually by Dependabot regardless of grouping.
   - package-ecosystem: npm
     directory: '/'
+    # Twice a month (cron can't express a strict 14-day cadence) — weekly was
+    # more review churn than the bumps were worth (#42). Security updates are
+    # raised immediately regardless of this schedule.
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: '0 8 1,15 * *'
     open-pull-requests-limit: 10
     groups:
       dev-dependencies:
@@ -34,7 +38,8 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: '0 8 1,15 * *'
     labels:
       - dependencies
       - github_actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
         dependency-type: development
       production-dependencies:
         dependency-type: production
+    # Setting `labels` replaces Dependabot's defaults, so the default pair is
+    # restated alongside `no-changelog`, which satisfies the changelog gate —
+    # dependency bumps don't get CHANGELOG.md entries (see changelog.yml).
+    labels:
+      - dependencies
+      - javascript
+      - no-changelog
     ignore:
       # Held at 5.9.x pending a deliberate TS 7 migration. TS 6.0+ makes
       # our tsconfigs' `moduleResolution: node` (node10) a hard error
@@ -28,3 +35,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    labels:
+      - dependencies
+      - github_actions
+      - no-changelog


### PR DESCRIPTION
Two Dependabot config fixes:

**1. Auto-apply the `no-changelog` label.** Every merged Dependabot PR so far has needed the label applied by hand to pass the changelog gate — #87 and #88 sat blocked on it until labeled. Dependabot now applies it at PR creation. Since setting `labels` in `dependabot.yml` **replaces** Dependabot's defaults, the stock `dependencies` + ecosystem labels (`javascript` / `github_actions`) are restated explicitly, matching the label set on previously merged Dependabot PRs (#77, #81, etc.).

**2. Check for updates twice a month instead of weekly** (closes #42). Weekly batches were more review churn than the bumps were worth. Cron can't express a strict 14-day cadence, so the schedule runs on the 1st and 15th (`0 8 1,15 * *`, 08:00 UTC). Security updates are unaffected — Dependabot raises those immediately regardless of the version-update schedule.

Config validated against the SchemaStore `dependabot-2.0.json` schema.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)