### PR TITLE
docs: Update PR template to have AI disclosure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,8 @@
 - [ ] Linting passes (`npm run lint`)
 - [ ] PR description clearly explains the purpose and implementation
 
-### AI Evaluations (for MCP tool/prompt changes)
+
+### Evaluations (for MCP tool/prompt changes)
 
 - [ ] New/updated eval questions added for new functionality
       (`packages/zowe-mcp-evals/questions/`)
@@ -37,3 +38,13 @@
 ### Regression Justification (if applicable)
 
 <!-- If any eval set shows a pass rate drop, explain why it is acceptable. -->
+
+### AI Usage Disclosure
+
+Document how AI was used in this pull request:
+
+- **Tool**: Which AI assistant was used (e.g. Cursor, GitHub Copilot, Claude
+  Code, Cline)
+- **Model**: Which model(s) were used (e.g. Claude Sonnet 4, GPT-4.1)
+- **Scope**: What parts of the PR were AI-assisted vs. manually written
+- **Review**: How the AI-generated code was reviewed and validated


### PR DESCRIPTION
## Description

Add "AI Usage" section to the PR template, as it is required. Template is based on what was written in CONTRIBUTING.md

## Changes

- Add AI Usage section to PR template
- "AI Evaluations" -> "Evaluations" since we are not evaluating an AI, but rather evaluating the program. 

## Testing

N/A

## Checklist

### General

- [x] All commits are signed off (`git commit -s`)
- [x] Code compiles without errors (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

- [ ] New/updated eval questions added for new functionality
      (`packages/zowe-mcp-evals/questions/`)
- [ ] Baseline added to scoreboard for new eval sets
      (`npm run eval-compare -- --set <set> --label "baseline"`)
- [ ] `eval-compare` run for behavior changes (before/after labels in
      `docs/eval-scoreboard.md`)
- [x] No eval regressions (or justification provided below)

### AI Usage

None