### PR TITLE
fix(deps): clear the three production advisories blocking the audit gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ don't warrant an entry (CI, chores, internal refactors, docs-only) can carry the
 
 ### Fixed
 
+- **Cleared three production dependency advisories** that had been failing the
+  `audit` gate on `main` since 2026-09-02 and therefore blocking every PR:
+  `fast-uri` 3.1.5 → 3.1.7 (high — host confusion and SSRF via IDN/IPv6/percent-decoding
+  handling, reached through `ajv`), `sanitize-html` 2.17.6 → 2.17.7 (moderate — stored
+  XSS via SVG SMIL URI-list scheme-policy bypass, reached through `@zowe/imperative`),
+  and `qs` 6.15.2 → 6.16.0 (moderate — array-limit bypass and DoS via attacker-controlled
+  `isBuffer`, reached through `express`). Transitive upgrades only; no direct dependency
+  ranges changed.
 - **`generate-docs` could crash outside the monorepo.** `markdown-table-prettify`
   was loaded through an undeclared (phantom) dependency that only resolved via
   monorepo hoisting; it is now a declared dependency and statically bundled, so

--- a/package-lock.json
+++ b/package-lock.json
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3802,15 +3802,51 @@
       }
     },
     "node_modules/express/node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/qs/node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/qs/node_modules/side-channel/node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8754,6 +8790,7 @@
       "version": "1.1.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8773,6 +8810,7 @@
       "version": "1.0.0",
       "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12555,9 +12593,9 @@
       }
     },
     "packages/zowe-mcp-evals/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -14062,9 +14100,9 @@
       }
     },
     "packages/zowe-mcp-server/node_modules/@zowe/imperative/node_modules/sanitize-html": {
-      "version": "2.17.6",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/sanitize-html/-/sanitize-html-2.17.6.tgz",
-      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "version": "2.17.7",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -14412,9 +14450,9 @@
       }
     },
     "packages/zowe-mcp-server/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -16671,9 +16709,9 @@
       }
     },
     "packages/zowe-mcp-vscode/node_modules/@zowe/imperative/node_modules/sanitize-html": {
-      "version": "2.17.6",
-      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/sanitize-html/-/sanitize-html-2.17.6.tgz",
-      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "version": "2.17.7",
+      "resolved": "https://zowe.jfrog.io/artifactory/api/npm/npm-release/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",


### PR DESCRIPTION
## Why

The required `audit` check (`npm audit --omit=dev --audit-level=moderate`) has been failing on `main` since 2026-09-02 — every scheduled run against `048890e` fails, and the last success was the 2026-09-01 push. Because `audit` is a required status check, this blocks **every** PR into `main`, not just one.

Found while reviewing #106, whose only remaining red check was this pre-existing failure.

## What

Three transitive production advisories, all fixable inside the existing semver ranges via `npm audit fix`:

| Package | Change | Severity | Reached through | Advisory |
| --- | --- | --- | --- | --- |
| `fast-uri` | 3.1.5 → 3.1.7 | high | `ajv` / `ajv-formats` | host confusion via skipped IDN canonicalization; SSRF via malformed IPv6 normalization; SSRF via repeated hostname percent-decoding; host confusion via percent-encoded scheme normalization |
| `sanitize-html` | 2.17.6 → 2.17.7 | moderate | `@zowe/imperative` | stored XSS via SVG SMIL URI-list scheme-policy bypass |
| `qs` | 6.15.2 → 6.16.0 | moderate | `express` | array-limit bypass via bracket-key comma parsing; DoS via attacker-controlled `isBuffer` |

`qs` brings in `side-channel` and `side-channel-list` as new transitives.

This is a **`package-lock.json` change only** — no `package.json` range was touched and no direct dependency moved.

## Verification

| Check | Result |
| --- | --- |
| `npm audit --omit=dev --audit-level=moderate` | **0 vulnerabilities** (was 3) |
| `npm ci` | clean |
| build `zowe-mcp-common` → `@zowe/mcp-server` | pass |
| `npm run test -w @zowe/mcp-server` | 972 passed, 113 skipped (71 files) |
| `npm run lint` | clean |
| `npm run check-format` | clean |

Once this merges, #106 needs `main` merged into it so its own `audit` run picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwUYntyVEP92TL26Bee9AJ
