### PR TITLE
fix(vscode): fall back to user settings when no workspace is open

### DIFF
--- a/packages/zowe-mcp-vscode/CHANGELOG.md
+++ b/packages/zowe-mcp-vscode/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Zowe MCP extension will be documented in this file.
 
 ## Recent Changes
 
+### Bug fixes
+
+- **Setting a mock data directory failed with "Unable to write to Workspace Settings because no workspace is opened"** when no folder was open in the editor. The extension now saves `zoweMCP.mockDataDirectory` to user settings in that case, falling back to workspace settings only when a workspace is open. [#107](https://github.com/zowe/zowe-mcp/issues/107)
+
 ### Other
 
 - **Much faster installs**: The extension VSIX is now esbuild-bundled (extension host and MCP server) instead of shipping a full `npm install` of every production dependency. This cuts the packaged file count and removes duplicate copies of large native binaries, which noticeably speeds up installation, especially on Windows. [#54](https://github.com/zowe/zowe-mcp/issues/54)

--- a/packages/zowe-mcp-vscode/src/extension.ts
+++ b/packages/zowe-mcp-vscode/src/extension.ts
@@ -603,6 +603,20 @@ async function updateCursorRegistration(
 }
 
 /**
+ * Picks Workspace scope when a workspace is open, otherwise falls back to
+ * Global so settings updates don't fail with "no workspace is opened".
+ */
+export function pickConfigTarget(): {
+  target: vscode.ConfigurationTarget;
+  scopeLabel: string;
+} {
+  const hasWorkspace = (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
+  return hasWorkspace
+    ? { target: vscode.ConfigurationTarget.Workspace, scopeLabel: 'workspace settings' }
+    : { target: vscode.ConfigurationTarget.Global, scopeLabel: 'user settings' };
+}
+
+/**
  * Generates mock z/OS data by running the bundled server's `init-mock` command.
  *
  * Prompts the user for an output directory, runs the generator, and offers
@@ -716,12 +730,13 @@ async function initMockData(
 
   if (choice === configure) {
     const config = vscode.workspace.getConfiguration('zoweMCP');
-    await config.update('mockDataDirectory', outputDir, vscode.ConfigurationTarget.Workspace);
-    log.info(`Set zoweMCP.mockDataDirectory to: ${outputDir}`);
+    const { target, scopeLabel } = pickConfigTarget();
+    await config.update('mockDataDirectory', outputDir, target);
+    log.info(`Set zoweMCP.mockDataDirectory to: ${outputDir} (${scopeLabel})`);
 
     const reload = 'Reload Window';
     const reloadChoice = await vscode.window.showInformationMessage(
-      'Mock data directory configured. Reload the window to restart the MCP server with mock data.',
+      `Mock data directory saved to ${scopeLabel}. Reload the window to restart the MCP server with mock data.`,
       reload
     );
     if (reloadChoice === reload) {
@@ -755,15 +770,12 @@ async function promptForMockDataDirectory(): Promise<void> {
     });
     if (folders && folders.length > 0) {
       const config = vscode.workspace.getConfiguration('zoweMCP');
-      await config.update(
-        'mockDataDirectory',
-        folders[0].fsPath,
-        vscode.ConfigurationTarget.Workspace
-      );
-      log.info(`Set zoweMCP.mockDataDirectory to: ${folders[0].fsPath}`);
+      const { target, scopeLabel } = pickConfigTarget();
+      await config.update('mockDataDirectory', folders[0].fsPath, target);
+      log.info(`Set zoweMCP.mockDataDirectory to: ${folders[0].fsPath} (${scopeLabel})`);
       const reload = 'Reload Window';
       const reloadChoice = await vscode.window.showInformationMessage(
-        'Mock data directory configured. Reload the window to restart the MCP server with mock data.',
+        `Mock data directory saved to ${scopeLabel}. Reload the window to restart the MCP server with mock data.`,
         reload
       );
       if (reloadChoice === reload) {

--- a/packages/zowe-mcp-vscode/src/test/extension.test.ts
+++ b/packages/zowe-mcp-vscode/src/test/extension.test.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   buildServerConfig,
+  pickConfigTarget,
   provideZoweMcpServerDefinitions,
   showNoConnectionsNotificationIfNeeded,
 } from '../extension';
@@ -473,6 +474,59 @@ suite('Zowe MCP VS Code Extension', () => {
         serverConfig.args.includes('zowemcp-test-user@127.0.0.1'),
         'args should include --system value from real settings'
       );
+    });
+  });
+
+  suite('pickConfigTarget', () => {
+    // workspaceFolders is a getter-only property on the vscode namespace, so a
+    // plain assignment throws. Swap in a value descriptor and restore the
+    // original accessor afterwards.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      vscode.workspace,
+      'workspaceFolders'
+    );
+
+    function setWorkspaceFolders(value: readonly vscode.WorkspaceFolder[] | undefined): void {
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value,
+        configurable: true,
+        enumerable: true,
+      });
+    }
+
+    teardown(() => {
+      assert.ok(originalDescriptor, 'workspaceFolders descriptor should exist');
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', originalDescriptor);
+    });
+
+    test('returns Workspace/"workspace settings" when a workspace is open', () => {
+      setWorkspaceFolders([
+        {
+          uri: vscode.Uri.file('/tmp/some-workspace'),
+          name: 'some-workspace',
+          index: 0,
+        },
+      ]);
+
+      const { target, scopeLabel } = pickConfigTarget();
+      assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
+      assert.strictEqual(scopeLabel, 'workspace settings');
+    });
+
+    test('returns Global/"user settings" when workspaceFolders is undefined', () => {
+      setWorkspaceFolders(undefined);
+
+      const { target, scopeLabel } = pickConfigTarget();
+      assert.strictEqual(target, vscode.ConfigurationTarget.Global);
+      assert.strictEqual(scopeLabel, 'user settings');
+    });
+
+    test('returns Global/"user settings" when workspaceFolders is an empty array', () => {
+      setWorkspaceFolders([]);
+
+      const { target, scopeLabel } = pickConfigTarget();
+      assert.strictEqual(target, vscode.ConfigurationTarget.Global);
+      assert.strictEqual(scopeLabel, 'user settings');
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #107. With no folder open in VS Code, configuring a mock data directory failed outright:

```
Unable to write to Workspace Settings because no workspace is opened.
```

Both writers of `zoweMCP.mockDataDirectory` — the **Use as Mock Data** action after `zowe-mcp.initMockData`, and the **Select Existing Directory** prompt shown when the backend is `mock` but no directory is set — passed `ConfigurationTarget.Workspace` unconditionally. That target is invalid in an empty window, so the mock-data flow could not be completed at all there.

`resetZoweMcpState` already guarded its Workspace write with a `workspaceFolders` check; this brings the two mock-directory writers in line with that existing idiom.

## Changes

- `packages/zowe-mcp-vscode/src/extension.ts` — new `pickConfigTarget()` returning `{ target, scopeLabel }`: `Workspace` when `workspace.workspaceFolders` is non-empty, `Global` otherwise. Both call sites use it, and the log line plus the follow-up reload prompt now name the scope actually written ("Mock data directory saved to user settings…") rather than saying "configured" without saying where.
- `packages/zowe-mcp-vscode/src/test/extension.test.ts` — covers the helper for folders-present, `undefined`, and empty-array.
- `packages/zowe-mcp-vscode/CHANGELOG.md` — bug-fix entry under Recent Changes.

## Testing

- `npm test -w packages/zowe-mcp-vscode` — 21 passing, 0 failing, against a real VS Code 1.136.1 instance.
- `npm run build`, `npm run lint` (`--max-warnings 0`), `npm run check-format`, `npm run lint:md` — all clean.

Not exercised by hand in an empty VS Code window; the coverage is the unit-level helper plus the existing suite. The failing write is a documented VS Code API constraint rather than something subtle, so I judged the helper test sufficient — say the word if you want a manual pass before merge.

### Note on provenance

The `extension.ts` change re-applies 4d44be9, written earlier on a local branch that never landed and had drifted well behind `main` (it carried a `chore: release v0.9.0` and a `0.10.0-dev` version bump, so merging it was not an option). The test, the export, and the changelog entry are new here — the original commit had none of them.

One thing worth a reviewer's eye: `workspaceFolders` is a **getter-only** property on the `vscode` namespace, so the natural test approach — assigning to it, the way this test file already monkey-patches `getConfiguration` — throws `TypeError: Cannot set property workspaceFolders of #<Object> which has only a getter`, and a failing `teardown` then aborts the rest of the suite. The test swaps in a value descriptor via `Object.defineProperty` and restores the captured original accessor instead.

## Checklist

### General

- [x] All commits are signed off (`git commit -s`)
- [x] Code compiles without errors (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] PR description clearly explains the purpose and implementation

### AI Evaluations (for MCP tool/prompt changes)

Not applicable — VS Code extension settings-scope fix. No MCP tool, prompt, or resource behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwUYntyVEP92TL26Bee9AJ
