### PR TITLE
fix(security): resolve triaged CodeQL findings and stop suppressed ESLint findings becoming alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,17 @@ jobs:
         if: ${{ !cancelled() && steps.build-for-lint.outcome == 'success' }}
         continue-on-error: true
         run: npm run lint:sarif
+
+      # The SARIF formatter emits rules silenced by an inline `eslint-disable` comment as
+      # ordinary `level: "error"` results tagged `suppressions: [{ kind: "inSource" }]`, and
+      # GitHub does not honour that tag — so every reviewed suppression became a permanently
+      # open alert that `npm run lint` (the actual gate, above) is happy with. Strip them so
+      # the Security tab agrees with the lint gate.
+      - name: Drop suppressed results from SARIF
+        if: ${{ !cancelled() && hashFiles('eslint-results.sarif') != '' }}
+        continue-on-error: true
+        run: node scripts/filter-sarif-suppressions.mjs
+
       - name: Upload ESLint SARIF
         # security-events:write is unavailable to fork-PR tokens — skip there.
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,35 @@ don't warrant an entry (CI, chores, internal refactors, docs-only) can carry the
 
 ### Fixed
 
+- **Unauthenticated crash on the HTTP transport.** `startHttp` kept its active
+  sessions in a plain object indexed by the client-supplied `mcp-session-id`
+  header, so a request carrying `mcp-session-id: __proto__` (or `constructor`,
+  `toString`) matched an inherited property, took the known-session branch, and
+  crashed the request on an `undefined` transport. All three `/mcp` endpoints
+  (POST, GET, DELETE) were affected, and no valid token was needed to trigger
+  it. This was a denial of service, not an authentication bypass — an inherited
+  entry can never resolve to a real transport, and JWT verification was
+  unaffected. Sessions are now held in a `Map`.
+- **Data set patterns containing `$` never matched** in the mock backend's
+  `matchPattern`. Pattern qualifiers were interpolated into a regular expression
+  with only `*` translated, leaving every other metacharacter live, so the `$`
+  in a perfectly legal qualifier such as `SYS1.A$B` compiled to an
+  end-of-string anchor. Qualifiers are now escaped before the wildcard is
+  translated, which also stops qualifiers containing `(`, `[`, or `+` from
+  throwing or silently changing the match.
+- Generated temp data set qualifiers were drawn with a biased modulo (`% 26` /
+  `% 36` over a random byte), skewing them toward earlier letters and slightly
+  raising the collision rate. They are now sampled uniformly.
+- Connection profiles written by the evals harness, which can contain
+  credentials, were written to a predictably named file directly under a
+  world-readable temp directory. They now go into a per-run private (0700)
+  directory with 0600 permissions.
+- Hardened three smaller paths flagged by CodeQL: keys arriving from the MCP
+  server are validated before indexing the VS Code settings objects they are
+  merged into, the mock host's `Authorization: Basic` parser no longer uses a
+  regular expression with ambiguous backtracking, and the docs generator now
+  escapes backslashes as well as quotes when quoting YAML strings.
+  ([#109](https://github.com/zowe/zowe-mcp/issues/109))
 - **Cleared three production dependency advisories** that had been failing the
   `audit` gate on `main` since 2026-09-02 and therefore blocking every PR:
   `fast-uri` 3.1.5 → 3.1.7 (high — host confusion and SSRF via IDN/IPv6/percent-decoding

--- a/packages/zowe-mcp-evals/src/harness.ts
+++ b/packages/zowe-mcp-evals/src/harness.ts
@@ -309,6 +309,12 @@ export class McpEvalHarness {
   private mockServerDirs: string[] = [];
   /** Resolved port per mock server name (set in startGenericMockServer, read in start()). */
   private mockServerPorts = new Map<string, number>();
+  /**
+   * Private (0700) temp directories holding CLI plugin connection files. Kept separate from
+   * mockServerDirs because that array is also read positionally (`.at(-1)`) as a legacy data-dir
+   * fallback. Removed in stop().
+   */
+  private credentialDirs: string[] = [];
 
   constructor(private options: HarnessOptions) {}
 
@@ -356,11 +362,16 @@ export class McpEvalHarness {
         const pluginsDir =
           setConfig.cliPluginsDir ?? resolve(dirname(mcpScript), 'tools', 'cli-bridge', 'plugins');
         args.push('--cli-plugins-dir', pluginsDir);
+        // Connection profiles can contain credentials, so write them into a private
+        // (0700) temp directory rather than directly under the shared, world-readable
+        // tmpdir() with a predictable name.
+        const cliPluginConnDir = mkdtempSync(join(tmpdir(), 'zowe-mcp-evals-'));
+        this.credentialDirs.push(cliPluginConnDir);
         for (const [pluginName, conn] of Object.entries(effectiveConnections)) {
           const { profilesFile, passwordEnvVars: pluginPasswordEnvVars } =
             resolveCliPluginConnection(pluginName, conn);
-          const connFile = join(tmpdir(), `cli-plugin-conn-${pluginName}-${Date.now()}.json`);
-          writeFileSync(connFile, JSON.stringify(profilesFile));
+          const connFile = join(cliPluginConnDir, `cli-plugin-conn-${pluginName}.json`);
+          writeFileSync(connFile, JSON.stringify(profilesFile), { mode: 0o600 });
           args.push('--cli-plugin-configuration', `${pluginName}=${connFile}`);
           // Merge plugin password env vars into the process env for the server
           Object.assign(passwordEnvVarsForServer, pluginPasswordEnvVars);
@@ -492,10 +503,11 @@ export class McpEvalHarness {
       log.info('Mock server(s) stopped', { count: this.mockServerProcesses.length });
       this.mockServerProcesses = [];
     }
-    for (const dir of this.mockServerDirs) {
+    for (const dir of [...this.mockServerDirs, ...this.credentialDirs]) {
       rmSync(dir, { recursive: true, force: true });
     }
     this.mockServerDirs = [];
+    this.credentialDirs = [];
   }
 
   /**

--- a/packages/zowe-mcp-server/src/mock-host/zosmf/middleware/auth.ts
+++ b/packages/zowe-mcp-server/src/mock-host/zosmf/middleware/auth.ts
@@ -30,7 +30,7 @@ export interface BasicAuthCredentials {
 export function parseBasicAuth(req: Request): BasicAuthCredentials | undefined {
   const header = req.header('authorization');
   if (!header) return undefined;
-  const match = /^Basic\s+(.+)$/i.exec(header.trim());
+  const match = /^Basic\s+(\S.*)$/i.exec(header.trim());
   if (!match) return undefined;
   let decoded: string;
   try {

--- a/packages/zowe-mcp-server/src/scripts/generate-docs.ts
+++ b/packages/zowe-mcp-server/src/scripts/generate-docs.ts
@@ -182,7 +182,7 @@ function yamlStringify(obj: Record<string, Record<string, unknown>>): string {
         lines.push(`  ${k}: ${v}`);
       } else if (typeof v === 'string') {
         if (v.includes("'") || v.includes('"') || v.includes('\n')) {
-          lines.push(`  ${k}: "${v.replace(/"/g, '\\"')}"`);
+          lines.push(`  ${k}: "${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
         } else {
           lines.push(`  ${k}: "${v}"`);
         }

--- a/packages/zowe-mcp-server/src/transports/http.ts
+++ b/packages/zowe-mcp-server/src/transports/http.ts
@@ -186,8 +186,10 @@ export async function startHttp(
     logOidcRegistrationDiscovery(jwtAuth.issuer, log);
   }
 
-  /** Map of active session ID → transport and optional JWT subject. */
-  const sessions: Record<string, SessionEntry> = {};
+  // Map of active session ID → transport and optional JWT subject. A Map (rather than a plain
+  // object) is used because the key is the client-controlled `mcp-session-id` header — an object
+  // would let values like `__proto__` resolve through the prototype chain instead of missing.
+  const sessions = new Map<string, SessionEntry>();
 
   async function verifyBearerOrRespond(
     req: Request,
@@ -242,8 +244,8 @@ export async function startHttp(
       }
       let transport: StreamableHTTPServerTransport;
 
-      if (sessionId && sessions[sessionId]) {
-        const entry = sessions[sessionId];
+      const entry = sessionId ? sessions.get(sessionId) : undefined;
+      if (entry) {
         const claims = await verifyBearerOrRespond(req, res, entry.sub);
         if (jwtAuth && claims === null) {
           return;
@@ -259,7 +261,7 @@ export async function startHttp(
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid: string) => {
-            sessions[sid] = { transport, sub: boundSub };
+            sessions.set(sid, { transport, sub: boundSub });
             log.info('MCP session initialized', { mcpSessionId: sid, tenantSub: boundSub });
           },
           ...(dnsRebindingGuard
@@ -275,8 +277,8 @@ export async function startHttp(
 
         transport.onclose = () => {
           const sid = transport.sessionId;
-          if (sid && sessions[sid]) {
-            delete sessions[sid];
+          if (sid) {
+            sessions.delete(sid);
           }
         };
 
@@ -314,11 +316,11 @@ export async function startHttp(
   // -----------------------------------------------------------------------
   app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    if (!sessionId || !sessions[sessionId]) {
+    const entry = sessionId ? sessions.get(sessionId) : undefined;
+    if (!entry) {
       res.status(400).send('Invalid or missing session ID');
       return;
     }
-    const entry = sessions[sessionId];
     const claims = await verifyBearerOrRespond(req, res, entry.sub);
     if (jwtAuth && claims === null) {
       return;
@@ -331,11 +333,11 @@ export async function startHttp(
   // -----------------------------------------------------------------------
   app.delete('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    if (!sessionId || !sessions[sessionId]) {
+    const entry = sessionId ? sessions.get(sessionId) : undefined;
+    if (!entry) {
       res.status(400).send('Invalid or missing session ID');
       return;
     }
-    const entry = sessions[sessionId];
     try {
       const claims = await verifyBearerOrRespond(req, res, entry.sub);
       if (jwtAuth && claims === null) {

--- a/packages/zowe-mcp-server/src/zos/mock/filesystem-mock-backend.ts
+++ b/packages/zowe-mcp-server/src/zos/mock/filesystem-mock-backend.ts
@@ -164,8 +164,10 @@ export function matchPattern(dsn: string, pattern: string): boolean {
   const regexStr = qualifiers
     .map(q => {
       if (q === '**') return '.*';
-      // Replace * with [^.]* (match within qualifier)
-      return q.replace(/\*/g, '[^.]*');
+      // Escape all regex metacharacters first (so qualifiers like "A(1)" or "A+B" are
+      // treated literally), then translate the now-escaped `\*` into `[^.]*` (match
+      // within qualifier).
+      return q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[^.]*');
     })
     .join('\\.');
 

--- a/packages/zowe-mcp-server/src/zos/temp-dsn.ts
+++ b/packages/zowe-mcp-server/src/zos/temp-dsn.ts
@@ -42,16 +42,29 @@ export const REQUIRED_SAFETY_QUALIFIER = 'TMP';
 // ---------------------------------------------------------------------------
 
 /**
+ * Returns a uniformly distributed index in [0, n) by rejection sampling random bytes.
+ * A single byte is drawn per attempt; bytes falling in the biased tail (>= the largest
+ * multiple of `n` that fits in 256) are discarded and redrawn.
+ */
+function randomIndex(n: number): number {
+  const limit = Math.floor(256 / n) * n;
+  let byte: number;
+  do {
+    byte = randomBytes(1)[0];
+  } while (byte >= limit);
+  return byte % n;
+}
+
+/**
  * Generate an 8-char DSN-safe qualifier (first char A–Z, rest A–Z0–9).
- * Uses random bytes for uniqueness; no requirement for crypto randomness per plan.
+ * Draws unbiased characters via rejection sampling over crypto random bytes.
  */
 function uniqueQualifier(): string {
   const firstChar = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   const rest = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  const bytes = randomBytes(8);
-  let result = firstChar[bytes[0] % 26];
+  let result = firstChar[randomIndex(firstChar.length)];
   for (let i = 1; i < 8; i++) {
-    result += rest[bytes[i] % 36];
+    result += rest[randomIndex(rest.length)];
   }
   return result;
 }

--- a/packages/zowe-mcp-vscode/src/event-handler.ts
+++ b/packages/zowe-mcp-vscode/src/event-handler.ts
@@ -47,6 +47,18 @@ export function jobCardConnectionSpec(user: string, host: string, port?: number)
 }
 
 /**
+ * Setting keys that must never be used to index an object we spread and write back to
+ * configuration — these keys come from the MCP server (connection spec / plugin name) and
+ * could otherwise pollute the object's prototype chain.
+ */
+const FORBIDDEN_SETTING_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Returns whether `key` is safe to use as an object key when merging into a settings object. */
+function isSafeSettingKey(key: string): boolean {
+  return key.length > 0 && !FORBIDDEN_SETTING_KEYS.has(key);
+}
+
+/**
  * Turns pasted or typed job card text into newline-separated lines. Splits on whitespace
  * (space, tab, newline) before a JCL line start (`//` or `/*`) so one-line or multi-line paste works.
  */
@@ -447,6 +459,10 @@ async function handleStoreJobCard(
 ): Promise<void> {
   if (event.type !== 'store-job-card') return;
   const { connectionSpec, jobCard } = event.data;
+  if (!isSafeSettingKey(connectionSpec)) {
+    log.warn(`Refusing to store job card for unsafe connection spec: "${connectionSpec}"`);
+    return;
+  }
   const config = vscode.workspace.getConfiguration('zoweMCP');
   const current = config.get<Record<string, string | string[]>>('jobCards', {}) ?? {};
   const updated = { ...current, [connectionSpec]: jobCard };
@@ -465,6 +481,10 @@ async function handleStoreCliPluginProfiles(
 ): Promise<void> {
   if (event.type !== 'store-cli-plugin-profiles') return;
   const { pluginName, profilesFile } = event.data;
+  if (!isSafeSettingKey(pluginName)) {
+    log.warn(`Refusing to store CLI plugin profiles for unsafe plugin name: "${pluginName}"`);
+    return;
+  }
   const config = vscode.workspace.getConfiguration('zoweMCP');
   const current = config.get<Record<string, unknown>>('cliPluginConfiguration', {}) ?? {};
   const updated = { ...current, [pluginName]: profilesFile };

--- a/scripts/filter-sarif-suppressions.mjs
+++ b/scripts/filter-sarif-suppressions.mjs
@@ -1,0 +1,52 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/**
+ * Drops suppressed results from an ESLint SARIF report before it is uploaded to code scanning.
+ *
+ * `@microsoft/eslint-formatter-sarif` writes rules that were silenced by an inline
+ * `eslint-disable` comment into the report as ordinary `level: "error"` results, tagging them
+ * with `suppressions: [{ kind: "inSource" }]`. GitHub does not honour that tag on upload, so
+ * every deliberate, reviewed suppression became a permanently open high-severity alert in the
+ * Security tab — 26 of them, none of which `npm run lint` (which gates CI at --max-warnings 0)
+ * considers a problem. A standing backlog that size hides genuinely new findings.
+ *
+ * Removing them keeps the Security tab agreeing with the lint gate. The suppressions stay
+ * visible where they are actually reviewed: the `eslint-disable` comment in the source.
+ *
+ * Only results are filtered. `runs[].tool.driver.rules` is left untouched so the `ruleIndex`
+ * on every surviving result stays valid.
+ *
+ * Usage: node scripts/filter-sarif-suppressions.mjs [path-to-sarif]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const file = process.argv[2] ?? 'eslint-results.sarif';
+
+const sarif = JSON.parse(readFileSync(file, 'utf-8'));
+
+let removed = 0;
+let kept = 0;
+
+for (const run of sarif.runs ?? []) {
+  if (!Array.isArray(run.results)) continue;
+  const before = run.results.length;
+  run.results = run.results.filter(
+    r => !(Array.isArray(r.suppressions) && r.suppressions.length > 0)
+  );
+  removed += before - run.results.length;
+  kept += run.results.length;
+}
+
+writeFileSync(file, JSON.stringify(sarif));
+
+console.log(`Filtered ${file}: removed ${removed} suppressed result(s), kept ${kept}.`);


### PR DESCRIPTION
Triages the CodeQL backlog catalogued in #109, and fixes the root cause of the separate ESLint alert backlog. Of the 47 open CodeQL alerts: **34 dismissed** with written reasons, **10 fixed here**, **3 left open** pending a decision (below). All **26 ESLint alerts** are addressed by a CI fix rather than code changes — see the second section for why.

---

## Part 1 — CodeQL

### Fixed

**`transports/http.ts` — unauthenticated crash (the one that matters).** `sessions` was `Record<string, SessionEntry> = {}`, indexed by the client-controlled `mcp-session-id` header. A request with `mcp-session-id: __proto__` (or `constructor`, `toString`) makes `sessions[sessionId]` truthy through the prototype chain, so the code takes the known-session branch and crashes on an `undefined` transport. All three `/mcp` endpoints are affected. It is **not** an auth bypass — an inherited entry can never reach a real transport — but it is a remote unauthenticated DoS. Now a `Map`.

**`zos/temp-dsn.ts`** — `bytes[i] % 26` / `% 36` is modulo-biased (256 is a multiple of neither), skewing generated temp DSN qualifiers toward early letters. Replaced with rejection sampling.

**`zos/mock/filesystem-mock-backend.ts`** — DSN pattern qualifiers were spliced into a `RegExp` with only `*` translated, leaving every other metacharacter unescaped. Escaping now happens before the wildcard translation. This incidentally **fixes matching for DSNs containing `$`** — a legal z/OS qualifier character that previously compiled to an end-of-string anchor and so could never match.

**`mock-host/zosmf/middleware/auth.ts`** — `/^Basic\s+(.+)$/i` has ambiguous `\s+`/`.+` overlap (polynomial backtracking); anchored with `\S`.

**`vscode/event-handler.ts`** — keys arriving from the MCP server are validated before indexing settings objects. Defense in depth: a computed key in an object literal creates an own property rather than polluting the prototype, so this was not live.

**`evals/harness.ts`** — connection profiles, which can carry credentials, were written to a predictably named file directly under a world-readable `tmpdir()`. Now `0600` inside a per-run `mkdtemp` (`0700`) directory.

**`scripts/generate-docs.ts`** — YAML string quoting escaped `"` but not `\`.

### Dismissed (34)

Grouped by rationale: mock z/OS host routes (loopback-only test double) as *used in tests*; config-file-supplied URLs reaching `fetch` in developer tooling as *false positive*; TOCTOU in single-principal build scripts as *won't fix*; plus individually reasoned cases — markdown-table escaping read as a security sanitizer, and `passwordHash()` flagged as `js/insufficient-password-hash` when it is a truncated SHA-256 used only to correlate two log lines without writing the plaintext.

### Left open (3) — needs a decision

`js/missing-rate-limiting` #12/#13/#14 on the **shipped** `/mcp` endpoints. Unlike the seven mock-host alerts of the same rule, this transport listens on a real port. Adding `express-rate-limit` is a behavioural change to a live network surface and needs choices best not made unilaterally: what limit, per-IP or per-JWT-`sub` (sessions already bind to `sub`), and whether deployments sit behind a gateway that handles this. If it is out of scope, dismissing these three takes the repo to zero open CodeQL alerts.

---

## Part 2 — ESLint

**There was no lint debt.** `npm run lint --max-warnings 0` (the CI gate) passes clean, and so does a full uncached run over all 269 files. All 26 alerts are rules deliberately silenced by an inline `eslint-disable` comment.

`@microsoft/eslint-formatter-sarif` writes suppressed rules into the report as ordinary `level: "error"` results tagged `suppressions: [{ kind: "inSource", justification: "" }]`. GitHub does not honour that tag on upload, so each became a permanently open alert. The tell was that **every analysis since 2026-06-16 reported exactly 26 results** regardless of branch or content — 19 of them from the single file-level disable at `native-backend.test.ts:17`.

So this filters suppressed results out of the SARIF before upload, rather than editing 26 call sites to appease rules the repo has already decided not to enforce. The suppressions stay visible where they are actually reviewed: the `eslint-disable` comment in the source. Only results are dropped — the driver `rules` array is left intact so `ruleIndex` on surviving results stays valid, and unsuppressed findings still upload normally (verified against a synthetic report).

The 26 existing alerts close themselves once a clean analysis lands on main.

---

## Verification

`typecheck`, `build`, `lint` (`--max-warnings 0`), `check-format` clean. Tests: server **972 passed / 113 skipped**, vscode **18 passing**, evals **145 passed**. No failures.

Refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwUYntyVEP92TL26Bee9AJ